### PR TITLE
Fix traceback.print_exception use

### DIFF
--- a/sh_scrapy/crawl.py
+++ b/sh_scrapy/crawl.py
@@ -65,7 +65,7 @@ def _fatalerror():
     # Inspired by logging.Handler.handleError()
     try:
         print >>_sys_stderr, datetime.datetime.utcnow().isoformat(),
-        traceback.print_exc(ei[0], ei[1], ei[2], None, _sys_stderr)
+        traceback.print_exception(ei[0], ei[1], ei[2], None, _sys_stderr)
     except IOError:
         pass
     finally:


### PR DESCRIPTION
Small typo fix for traceback.print_exception use ([print_exc](https://docs.python.org/2/library/traceback.html#traceback.print_exc) vs [print_exception](https://docs.python.org/2/library/traceback.html#traceback.print_exception)).