### PR TITLE
Fixing script names starting from [py:]

### DIFF
--- a/sh_scrapy/crawl.py
+++ b/sh_scrapy/crawl.py
@@ -93,6 +93,8 @@ def _run_scrapy(argv, settings):
 
 def _run_pkgscript(argv):
     import pkg_resources
+    if argv[0].startswith('py:'):
+        argv[0] = argv[0][3:]
     scriptname = argv[0]
     sys.argv = argv
 


### PR DESCRIPTION
Small patch fixing scripts names starting from `py:`.
Related with investigation for `ryerson-crawler`, but is also critical for all crawlers with periodic jobs.
In a similar way as [here](https://github.com/scrapinghub/hworker/blob/c1a440e7bed6587239209923a4d5a7c3a1a1c025/hworker/jobrunner/utils.py#L36).