### PR TITLE
Replace a few Scrapy plugins paths when no hworker

### DIFF
--- a/sh_scrapy/settings.py
+++ b/sh_scrapy/settings.py
@@ -2,6 +2,14 @@ import sys, os, tempfile
 from scrapy.utils.project import get_project_settings
 from scrapy.settings.default_settings import EXTENSIONS_BASE, SPIDER_MIDDLEWARES_BASE
 
+
+REPLACE_ADDONS_PATHS = {
+    "hworker.bot.ext.page.PageStorageMiddleware":
+        "scrapy_pagestorage.PageStorageMiddleware",
+    "hworker.bot.ext.persistence.DotScrapyPersistence":
+        "scrapy_dotpersistence.DotScrapyPersistence",
+}
+
 try:
     from scrapy.utils.deprecate import update_classpath
 except ImportError:
@@ -42,7 +50,10 @@ def _load_addons(addons, s, o):
             try:
                 import hworker
             except ImportError:
-                continue  # ignore missing module
+                if addon['path'] in REPLACE_ADDONS_PATHS:
+                    addon['path'] = REPLACE_ADDONS_PATHS[addon['path']]
+                else:
+                    continue  # ignore missing module
 
         skey = _get_component_base(s, addon['type'])
         components = s[skey]


### PR DESCRIPTION
We have moved out a few Scrapy addons (DotPersistence, PageStorage) from hworker library, so we need to replace it with correct ones when loading addons.

Review, please.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/scrapinghub/scrapinghub-entrypoint-scrapy/10)
<!-- Reviewable:end -->
