### PR TITLE
Providing separate entrypoint to run list-spiders

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -14,6 +14,7 @@ setup(
     entry_points={
         'console_scripts': [
             'start-crawl = sh_scrapy.crawl:main',
+            'list-spiders = sh_scrapy.crawl:list',
         ],
     },
 )

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ setup(
     entry_points={
         'console_scripts': [
             'start-crawl = sh_scrapy.crawl:main',
-            'list-spiders = sh_scrapy.crawl:list',
+            'list-spiders = sh_scrapy.crawl:list_spiders',
         ],
     },
 )

--- a/sh_scrapy/crawl.py
+++ b/sh_scrapy/crawl.py
@@ -161,21 +161,13 @@ def list_spiders():
         from scrapy.exceptions import ScrapyDeprecationWarning
         warnings.filterwarnings(
             'ignore', category=ScrapyDeprecationWarning, module='^sh_scrapy')
-        from sh_scrapy.env import get_scrapy_list_args_and_env, decode_uri
-        job_settings = decode_uri(envvar='JOB_SETTINGS')
-        assert job_settings, 'JOB_SETTINGS must be set'
-        project_id = job_settings.get('project')
-        assert project_id, 'JOB_SETTINGS must contain project'
-        args, env = get_scrapy_list_args_and_env(project_id)
-        os.environ.update(env)
-
         from sh_scrapy.env import setup_environment
         setup_environment()
     except:
         _fatalerror()
         raise
 
-    _run_usercode(None, args, _get_apisettings)
+    _run_usercode(None, ['scrapy', 'list'], _get_apisettings)
 
 
 def main():

--- a/sh_scrapy/crawl.py
+++ b/sh_scrapy/crawl.py
@@ -155,7 +155,7 @@ def _launch():
     _run_usercode(job['spider'], args, _get_apisettings, loghdlr)
 
 
-def _launch_list():
+def list():
     """ An entrypoint for list-spiders."""
     try:
         from scrapy.exceptions import ScrapyDeprecationWarning
@@ -174,14 +174,6 @@ def _launch_list():
         raise
 
     _run_usercode(None, args, _get_apisettings)
-
-
-def list():
-    try:
-        _launch_list()
-    finally:
-        sys.stderr = _sys_stderr
-        sys.stdout = _sys_stdout
 
 
 def main():

--- a/sh_scrapy/crawl.py
+++ b/sh_scrapy/crawl.py
@@ -155,16 +155,18 @@ def _launch():
     _run_usercode(job['spider'], args, _get_apisettings, loghdlr)
 
 
-def list():
+def list_spiders():
     """ An entrypoint for list-spiders."""
     try:
         from scrapy.exceptions import ScrapyDeprecationWarning
         warnings.filterwarnings(
             'ignore', category=ScrapyDeprecationWarning, module='^sh_scrapy')
         from sh_scrapy.env import get_scrapy_list_args_and_env, decode_uri
-        job = decode_uri(envvar='JOB_DATA')
-        assert job, 'JOB_DATA must be set'
-        args, env = get_scrapy_list_args_and_env(job)
+        job_settings = decode_uri(envvar='JOB_SETTINGS')
+        assert job_settings, 'JOB_SETTINGS must be set'
+        project_id = job_settings.get('project')
+        assert project_id, 'JOB_SETTINGS must contain project'
+        args, env = get_scrapy_list_args_and_env(project_id)
         os.environ.update(env)
 
         from sh_scrapy.env import setup_environment

--- a/sh_scrapy/crawl.py
+++ b/sh_scrapy/crawl.py
@@ -133,8 +133,8 @@ def _run_usercode(spider, args, apisettings_func, log_handler=None):
 def _launch():
     try:
         from scrapy.exceptions import ScrapyDeprecationWarning
-        warnings.filterwarnings('ignore', category=ScrapyDeprecationWarning, module='^sh_scrapy')
-
+        warnings.filterwarnings(
+            'ignore', category=ScrapyDeprecationWarning, module='^sh_scrapy')
         from sh_scrapy.env import get_args_and_env, decode_uri
         job = decode_uri(envvar='JOB_DATA')
         assert job, 'JOB_DATA must be set'
@@ -153,6 +153,35 @@ def _launch():
         raise
 
     _run_usercode(job['spider'], args, _get_apisettings, loghdlr)
+
+
+def _launch_list():
+    """ An entrypoint for list-spiders."""
+    try:
+        from scrapy.exceptions import ScrapyDeprecationWarning
+        warnings.filterwarnings(
+            'ignore', category=ScrapyDeprecationWarning, module='^sh_scrapy')
+        from sh_scrapy.env import get_scrapy_list_args_and_env, decode_uri
+        job = decode_uri(envvar='JOB_DATA')
+        assert job, 'JOB_DATA must be set'
+        args, env = get_scrapy_list_args_and_env(job)
+        os.environ.update(env)
+
+        from sh_scrapy.env import setup_environment
+        setup_environment()
+    except:
+        _fatalerror()
+        raise
+
+    _run_usercode(None, args, _get_apisettings)
+
+
+def list():
+    try:
+        _launch_list()
+    finally:
+        sys.stderr = _sys_stderr
+        sys.stdout = _sys_stdout
 
 
 def main():

--- a/sh_scrapy/env.py
+++ b/sh_scrapy/env.py
@@ -13,9 +13,9 @@ def _make_scrapy_args(arg, args_dict):
     return args
 
 
-def get_scrapy_list_args_and_env(msg):
+def get_scrapy_list_args_and_env(project_id):
     args = ['scrapy', 'list']
-    env = {'SCRAPY_PROJECT_ID': msg['project']}
+    env = {'SCRAPY_PROJECT_ID': project_id}
     return args, env
 
 

--- a/sh_scrapy/env.py
+++ b/sh_scrapy/env.py
@@ -13,12 +13,6 @@ def _make_scrapy_args(arg, args_dict):
     return args
 
 
-def get_scrapy_list_args_and_env(project_id):
-    args = ['scrapy', 'list']
-    env = {'SCRAPY_PROJECT_ID': project_id}
-    return args, env
-
-
 def _scrapy_crawl_args_and_env(msg):
     args = ['scrapy', 'crawl', str(msg['spider'])] + \
         _make_scrapy_args('-a', msg.get('spider_args')) + \

--- a/sh_scrapy/env.py
+++ b/sh_scrapy/env.py
@@ -13,6 +13,12 @@ def _make_scrapy_args(arg, args_dict):
     return args
 
 
+def get_scrapy_list_args_and_env(msg):
+    args = ['scrapy', 'list']
+    env = {'SCRAPY_PROJECT_ID': msg['project']}
+    return args, env
+
+
 def _scrapy_crawl_args_and_env(msg):
     args = ['scrapy', 'crawl', str(msg['spider'])] + \
         _make_scrapy_args('-a', msg.get('spider_args')) + \


### PR DESCRIPTION
This change adds a separate entrypoint `list-spiders` to get spiders list using `sh-entrypoint-scapy` with proper applying project settings.

Review, please.

JIRA https://scrapinghub.atlassian.net/browse/SC-599

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/scrapinghub/scrapinghub-entrypoint-scrapy/14)
<!-- Reviewable:end -->
