### PR TITLE
[WIP] Add DiskUsage extension

### DIFF
--- a/sh_scrapy/diskusage.py
+++ b/sh_scrapy/diskusage.py
@@ -15,6 +15,7 @@ from scrapy.utils.engine import get_engine_status
 
 
 logger = logging.getLogger(__name__)
+DEFAULT_CHECK_INTERVAL = 300.0
 
 
 def get_disk_usage(folders):
@@ -54,7 +55,8 @@ class DiskUsage(object):
 
         self.space_limit = crawler.settings.getint('DISKUSAGE_SPACE_LIMIT_MB')*1024*1024
         self.inodes_limit = crawler.settings.getint('DISKUSAGE_INODES_LIMIT')
-        self.check_interval = crawler.settings.getfloat('DISKUSAGE_CHECK_INTERVAL_SECONDS')
+        self.check_interval = crawler.settings.getfloat(
+            'DISKUSAGE_CHECK_INTERVAL_SECONDS', DEFAULT_CHECK_INTERVAL)
 
         crawler.signals.connect(self.engine_started, signal=signals.engine_started)
         crawler.signals.connect(self.engine_stopped, signal=signals.engine_stopped)

--- a/sh_scrapy/diskusage.py
+++ b/sh_scrapy/diskusage.py
@@ -81,7 +81,7 @@ class DiskUsage(object):
         msg = None
         if self.inodes_limit and inodes > self.inodes_limit:
             msg = 'inodes limit ({} > {})'.format(inodes, self.inodes_limit)
-        if self.space_limit and space > self.space_limit:
+        elif self.space_limit and space > self.space_limit:
             msg = 'space limit ({}M > {}M)'.format(space, self.space_limit)
         if msg:
             self.crawler.stats.set_value('diskusage/limit_reached', 1)

--- a/sh_scrapy/diskusage.py
+++ b/sh_scrapy/diskusage.py
@@ -1,0 +1,107 @@
+"""
+DiskUsage extension.
+"""
+import os
+import logging
+from threading import Timer
+from subprocess import Popen, PIPE
+
+from twisted.internet import task
+
+from scrapy import signals
+from scrapy.exceptions import NotConfigured
+from scrapy.mail import MailSender
+from scrapy.utils.engine import get_engine_status
+
+
+logger = logging.getLogger(__name__)
+
+
+def get_folder_disk_usage(folders, timeout=300):
+    """ Get disk usage for current user.
+
+    :param folders: Folders to calculate disk usage for.
+    :type folders: a list of str
+
+    :param timeout: Sets a timer which will kill find
+                    process if it takes too long to execute.
+    :type folder: int
+
+    :return: ``(inodes_count, space_bytes)`` tuple
+    """
+    inodes = space = 0
+    find_process = Popen(
+        ['find'] + folders + ['-user', str(os.getuid()),
+        '-type', 'f', '-printf', '%s\n'], stdout=PIPE)
+    awk_process = Popen(['awk', "{i++;s+=$1}END{print i\" \"s}"],
+                        stdin=find_process.stdout, stdout=PIPE)
+    timer = Timer(timeout, find_process.kill)
+    try:
+        timer.start()
+        find_process.stdout.close()
+        result = awk_process.communicate()[0]
+        logger.debug('Find result: %s', result)
+        if result and result.strip():
+            inodes, space = [int(val) for val in result.strip().split(' ')]
+    except Exception as exc:
+        logger.warning("Find exception: %s", exc)
+    else:
+        if find_process.returncode == -9:
+            logger.warning("Find process killed after %s secs", timeout)
+    finally:
+        timer.cancel()
+    return inodes, space
+
+
+class DiskUsage(object):
+
+    FOLDERS = ['/scrapy', '/tmp']
+    FIND_TIMEOUT = 300
+
+    def __init__(self, crawler):
+        if not crawler.settings.getbool('DISKUSAGE_ENABLED'):
+            raise NotConfigured
+
+        self.crawler = crawler
+
+        self.space_limit = crawler.settings.getint('DISKUSAGE_SPACE_LIMIT_MB')*1024*1024
+        self.inodes_limit = crawler.settings.getint('DISKUSAGE_INODES_LIMIT')
+        self.check_interval = crawler.settings.getfloat('DISKUSAGE_CHECK_INTERVAL_SECONDS')
+
+        crawler.signals.connect(self.engine_started, signal=signals.engine_started)
+        crawler.signals.connect(self.engine_stopped, signal=signals.engine_stopped)
+
+    @classmethod
+    def from_crawler(cls, crawler):
+        return cls(crawler)
+
+    def engine_started(self):
+        inodes, space = get_folder_disk_usage(self.FOLDERS, self.FIND_TIMEOUT)
+        self.crawler.stats.set_value('diskusage/inodes/startup', inodes)
+        self.crawler.stats.set_value('diskusage/space/startup', space)
+        self.task = task.LoopingCall(self._task_handler)
+        self.task.start(self.check_interval, now=True)
+
+    def engine_stopped(self):
+        if self.task.running:
+            self.task.stop()
+
+    def _task_handler(self):
+        inodes, space = get_folder_disk_usage(self.FOLDERS, self.FIND_TIMEOUT)
+        self.crawler.stats.max_value('diskusage/inodes/max', inodes)
+        self.crawler.stats.max_value('diskusage/space/max', space)
+        msg = None
+        if self.inodes_limit and inodes > self.inodes_limit:
+            msg = 'inodes limit ({} > {})'.format(inodes, self.inodes_limit)
+        if self.space_limit and space > self.space_limit:
+            msg = 'space limit ({}M > {}M)'.format(space, self.space_limit)
+        if msg:
+            self.crawler.stats.set_value('diskusage/limit_reached', 1)
+            logger.error("Disk usage exceeded: %s. Shutting down Scrapy...",
+                         msg, extra={'crawler': self.crawler})
+            open_spiders = self.crawler.engine.open_spiders
+            if open_spiders:
+                for spider in open_spiders:
+                    self.crawler.engine.close_spider(spider, 'diskusage_exceeded')
+            else:
+                self.crawler.stop()

--- a/sh_scrapy/diskusage.py
+++ b/sh_scrapy/diskusage.py
@@ -85,13 +85,15 @@ class DiskUsage(object):
             msg = 'inodes limit ({} > {})'.format(inodes, self.inodes_limit)
         elif self.space_limit and space > self.space_limit:
             msg = 'space limit ({}M > {}M)'.format(space, self.space_limit)
-        if msg:
-            self.crawler.stats.set_value('diskusage/limit_reached', 1)
-            logger.error("Disk usage exceeded: %s. Shutting down Scrapy...",
-                         msg, extra={'crawler': self.crawler})
-            open_spiders = self.crawler.engine.open_spiders
-            if open_spiders:
-                for spider in open_spiders:
-                    self.crawler.engine.close_spider(spider, 'diskusage_exceeded')
-            else:
-                self.crawler.stop()
+        if not msg:
+            return
+
+        self.crawler.stats.set_value('diskusage/limit_reached', 1)
+        logger.error("Disk usage exceeded: %s. Shutting down Scrapy...",
+                        msg, extra={'crawler': self.crawler})
+        open_spiders = self.crawler.engine.open_spiders
+        if open_spiders:
+            for spider in open_spiders:
+                self.crawler.engine.close_spider(spider, 'diskusage_exceeded')
+        else:
+            self.crawler.stop()

--- a/sh_scrapy/diskusage.py
+++ b/sh_scrapy/diskusage.py
@@ -25,7 +25,7 @@ def get_folder_disk_usage(folders, timeout=300):
 
     :param timeout: Sets a timer which will kill find
                     process if it takes too long to execute.
-    :type folder: int
+    :type timeout: int
 
     :return: ``(inodes_count, space_bytes)`` tuple
     """

--- a/sh_scrapy/settings.py
+++ b/sh_scrapy/settings.py
@@ -93,6 +93,7 @@ def _load_default_settings(s):
     }
     extensions = {
         'scrapy.extensions.debug.StackTraceDump': 0,
+        'sh_scrapy.diskusage.DiskUsage': 0,
         'sh_scrapy.extension.HubstorageExtension': 100,
     }
 
@@ -108,6 +109,8 @@ def _load_default_settings(s):
     memory_limit = int(os.environ.get('SHUB_JOB_MEMORY_LIMIT', 950))
     s.setdict({
         'STATS_CLASS': 'sh_scrapy.stats.HubStorageStatsCollector',
+        'DISKUSAGE_ENABLED': True,
+        'DISKUSAGE_CHECK_INTERVAL_SECONDS': 60.0,
         'MEMUSAGE_ENABLED': True,
         'MEMUSAGE_LIMIT_MB': memory_limit,
         'WEBSERVICE_ENABLED': False,

--- a/tests/test_diskusage.py
+++ b/tests/test_diskusage.py
@@ -57,6 +57,12 @@ def du_extension():
     return DiskUsage(crawler)
 
 
+def test_diskusage_from_crawler():
+    settings = {'DISKUSAGE_ENABLED': True}
+    crawler = get_crawler(settings_dict=settings)
+    assert DiskUsage.from_crawler(crawler)
+
+
 def test_diskusage_init(du_extension):
     assert isinstance(du_extension.crawler, Crawler)
     assert du_extension.space_limit == 512 * 1024 * 1024

--- a/tests/test_diskusage.py
+++ b/tests/test_diskusage.py
@@ -1,0 +1,37 @@
+import mock
+import pytest
+
+from sh_scrapy.diskusage import get_disk_usage
+from sh_scrapy.diskusage import DiskUsage
+
+
+def test_get_disk_usage_wrong_usage():
+    with pytest.raises(AssertionError):
+        get_disk_usage([])
+
+
+@mock.patch('sh_scrapy.diskusage.Popen')
+def test_get_disk_usage_base_calls_check(popen):
+    assert get_disk_usage(['/tmp1', '/tmp2']) == (0, 0)
+    assert popen.called
+    assert popen.call_args_list[0] == (
+        (['find', '/tmp1', '/tmp2', '-user', '501', '-type',
+         'f', '-printf', '%s\n'],), {'stdout':-1})
+    assert popen.call_args_list[1] == (
+        (['awk', '{i++;s+=$1}END{print i" "s}'],),
+        {'stdin': popen.return_value.stdout, 'stdout': -1})
+    assert popen.return_value.stdout.close.called
+    assert popen.return_value.communicate.called
+
+
+@mock.patch('sh_scrapy.diskusage.Popen')
+def test_get_disk_usage_mock_result(popen):
+    find_result = '1234 100500\n'
+    popen.return_value.communicate.return_value = (find_result, None)
+    assert get_disk_usage(['/tmp']) == (1234, 100500)
+
+
+@mock.patch('sh_scrapy.diskusage.Popen')
+def test_get_disk_usage_swallow_exception(popen):
+    popen.return_value.communicate.side_effect = ValueError('crush!')
+    get_disk_usage(['/tmp']) == (0, 0)

--- a/tests/test_diskusage.py
+++ b/tests/test_diskusage.py
@@ -1,5 +1,9 @@
+import os
 import mock
 import pytest
+from scrapy.crawler import Crawler
+from scrapy.utils.test import get_crawler
+from scrapy.exceptions import NotConfigured
 
 from sh_scrapy.diskusage import get_disk_usage
 from sh_scrapy.diskusage import DiskUsage
@@ -15,8 +19,8 @@ def test_get_disk_usage_base_calls_check(popen):
     assert get_disk_usage(['/tmp1', '/tmp2']) == (0, 0)
     assert popen.called
     assert popen.call_args_list[0] == (
-        (['find', '/tmp1', '/tmp2', '-user', '501', '-type',
-         'f', '-printf', '%s\n'],), {'stdout':-1})
+        (['find', '/tmp1', '/tmp2', '-user', str(os.getuid()),
+         '-type', 'f', '-printf', '%s\n'],), {'stdout':-1})
     assert popen.call_args_list[1] == (
         (['awk', '{i++;s+=$1}END{print i" "s}'],),
         {'stdin': popen.return_value.stdout, 'stdout': -1})
@@ -35,3 +39,90 @@ def test_get_disk_usage_mock_result(popen):
 def test_get_disk_usage_swallow_exception(popen):
     popen.return_value.communicate.side_effect = ValueError('crush!')
     get_disk_usage(['/tmp']) == (0, 0)
+
+
+def test_diskusage_init_with_void_settings():
+    crawler = get_crawler(settings_dict = {})
+    with pytest.raises(NotConfigured):
+        DiskUsage(crawler)
+
+
+@pytest.fixture
+def du_extension():
+    settings = {'DISKUSAGE_ENABLED': True,
+                'DISKUSAGE_SPACE_LIMIT_MB': 512,
+                'DISKUSAGE_INODES_LIMIT': 80000,
+                'DISKUSAGE_CHECK_INTERVAL_SECONDS': 300}
+    crawler = get_crawler(settings_dict=settings)
+    return DiskUsage(crawler)
+
+
+def test_diskusage_init(du_extension):
+    assert isinstance(du_extension.crawler, Crawler)
+    assert du_extension.space_limit == 512 * 1024 * 1024
+    assert du_extension.inodes_limit == 80000
+    assert du_extension.check_interval == 300
+
+
+@mock.patch('twisted.internet.task.LoopingCall')
+@mock.patch('sh_scrapy.diskusage.get_disk_usage')
+def test_diskusage_engine_started(get_disk_usage, looping_call, du_extension):
+    get_disk_usage.return_value = (500, 1000)
+    du_extension.engine_started()
+    assert du_extension.crawler.stats.get_value(
+        'diskusage/inodes/startup') == 500
+    assert du_extension.crawler.stats.get_value(
+        'diskusage/space/startup') == 1000
+    assert looping_call.called
+    assert looping_call.call_args[0] == (du_extension._task_handler,)
+    assert du_extension.task
+    assert du_extension.task.start.called
+    assert du_extension.task.start.call_args == ((300,), {'now': True})
+
+
+def test_diskusage_engine_stopped(du_extension):
+    du_extension.task = mock.Mock()
+    du_extension.task.running = True
+    du_extension.engine_stopped()
+    assert du_extension.task.stop.called
+
+
+@mock.patch('sh_scrapy.diskusage.get_disk_usage')
+def test_diskusage_task_handler_max_stats(get_disk_usage, du_extension):
+    stats = du_extension.crawler.stats
+    stats.set_value('diskusage/inodes/max', 100)
+    stats.set_value('diskusage/space/max', 100000)
+    get_disk_usage.return_value = (500, 90000)
+    du_extension._task_handler()
+    assert stats.get_value('diskusage/inodes/max') == 500
+    assert stats.get_value('diskusage/space/max') == 100000
+
+
+@mock.patch('sh_scrapy.diskusage.get_disk_usage')
+def test_diskusage_task_handler_raise_limit(get_disk_usage, du_extension):
+    for disk_usage in [(500, 1024*1024*1024), (90000, 100)]:
+        get_disk_usage.return_value = disk_usage
+        du_extension.task = mock.Mock()
+        du_extension.task.running = True
+        engine_mock = mock.Mock()
+        engine_mock.open_spiders = [mock.Mock()]
+        du_extension.crawler.engine = engine_mock
+        du_extension.crawler.stop = mock.Mock()
+        du_extension._task_handler()
+        assert du_extension.crawler.stats.get_value(
+            'diskusage/limit_reached') == 1
+        assert engine_mock.close_spider.called
+        assert engine_mock.close_spider.call_args == (
+            (engine_mock.open_spiders[0], 'diskusage_exceeded'),)
+        assert not du_extension.crawler.stop.called
+
+
+@mock.patch('sh_scrapy.diskusage.get_disk_usage')
+def test_diskusage_task_handler_no_open_spiders(get_disk_usage, du_extension):
+    get_disk_usage.return_value = (500, 1024*1024*1024)
+    engine_mock = mock.Mock()
+    engine_mock.open_spiders = []
+    du_extension.crawler.engine = engine_mock
+    du_extension.crawler.stop = mock.Mock()
+    du_extension._task_handler()
+    assert du_extension.crawler.stop.called


### PR DESCRIPTION
The PR adds DiskUsage extension to control disk space and inodes consumption in the container and stop a crawler gently when running in Scrapy Cloud. The extensions is enabled by default with disabled limits to push nice stats which can help a lot with investigation.

Some notes:
- there's no native docker support for disk quotas, we have to rely on standard linux tools
- the most straightforward way is using `find & awk` combination to get inodes & space usage per a given user at the same time, should work almost instantly for general cases
- however when there're a lot of files, the call can take pretty much time, for instance it takes ~50secs to walk through a folder with 516MB and ~80k inodes
- ~~as it can take a lot of time, I added a timer with timeout (300s) killing `find` process if it takes to long to execute with a warning, it should be enough to warn a user that there's something wrong with disk usage behaviour (looks useful, but have some doubts about it though)~~ dropped the timer, doesn't make sense as LookingCall reschedules a task in a sensible way and waits for previous task to finish
- there's an alternative to use `du` / `wc` for `/scrapy` folder, as it has only the user files, but logic and timings are almost the same, we anyway have to traverse the directory recursively
- I decided not to add warnings & mail reports like MemUsage has, as not sure that it's really needed, the goal of this extension just to stop a spider gently before hitting hard limits.

The PR is created for review, don't merge please, at least it misses tests.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/scrapinghub/scrapinghub-entrypoint-scrapy/17)
<!-- Reviewable:end -->
