### PR TITLE
Rotating logs for Kumo jobs

### DIFF
--- a/sh_scrapy/settings.py
+++ b/sh_scrapy/settings.py
@@ -112,7 +112,6 @@ def _load_default_settings(s):
         'MEMUSAGE_LIMIT_MB': memory_limit,
         'WEBSERVICE_ENABLED': False,
         'LOG_LEVEL': 'INFO',
-        'LOG_FILE': 'scrapy.log',
         'TELNETCONSOLE_HOST': '0.0.0.0',  # to access telnet console from host
     }, priority='cmdline')
 


### PR DESCRIPTION
The PR does the following things:
- disable writing `scrapy.log` by default
- ~~patches Scrapy logic to use `RotatingFileHandler` on demand~~
- ~~a few additional settings to configure rotation process~~

JIRA https://scrapinghub.atlassian.net/browse/SC-693