### PR TITLE
Add DiskQuota middlewares

### DIFF
--- a/sh_scrapy/diskquota.py
+++ b/sh_scrapy/diskquota.py
@@ -1,0 +1,31 @@
+from scrapy import signals
+
+
+class DiskQuota(object):
+
+    def __init__(self, crawler):
+        if not crawler.settings.getbool('DISK_QUOTA_STOP_ON_ERROR'):
+            raise NotConfigured
+        self.crawler = crawler
+
+    @classmethod
+    def from_crawler(cls, crawler):
+        return cls(crawler)
+
+    def _is_disk_quota_error(self, error):
+        if isinstance(error, IOError):
+            return error.errno == 122 and error.strerror == 'Disk quota exceeded'
+
+
+class DiskQuotaDownloaderMiddleware(DiskQuota):
+
+    def process_exception(self, request, exception, spider):
+        if self._is_disk_quota_error(exception):
+            self.crawler.engine.close_spider(spider, 'diskusage_exceeded')
+
+
+class DiskQuotaSpiderMiddleware(DiskQuota):
+
+    def process_spider_exception(self, response, exception, spider):
+        if self._is_disk_quota_error(exception):
+            self.crawler.engine.close_spider(spider, 'diskusage_exceeded')

--- a/sh_scrapy/diskquota.py
+++ b/sh_scrapy/diskquota.py
@@ -3,6 +3,9 @@ DiskQuota downloader and spider middlewares.
 The goal is to catch disk quota errors and stop spider gently.
 """
 
+from scrapy.exceptions import NotConfigured
+
+
 class DiskQuota(object):
 
     def __init__(self, crawler):
@@ -16,7 +19,7 @@ class DiskQuota(object):
 
     def _is_disk_quota_error(self, error):
         if isinstance(error, IOError):
-            return error.errno == 122 and error.strerror == 'Disk quota exceeded'
+            return error.errno == 122
 
 
 class DiskQuotaDownloaderMiddleware(DiskQuota):

--- a/sh_scrapy/diskquota.py
+++ b/sh_scrapy/diskquota.py
@@ -18,8 +18,7 @@ class DiskQuota(object):
         return cls(crawler)
 
     def _is_disk_quota_error(self, error):
-        if isinstance(error, IOError):
-            return error.errno == 122
+        return isinstance(error, IOError) and error.errno == 122
 
 
 class DiskQuotaDownloaderMiddleware(DiskQuota):

--- a/sh_scrapy/diskquota.py
+++ b/sh_scrapy/diskquota.py
@@ -1,5 +1,7 @@
-from scrapy import signals
-
+"""
+DiskQuota downloader and spider middlewares.
+The goal is to catch disk quota errors and stop spider gently.
+"""
 
 class DiskQuota(object):
 

--- a/sh_scrapy/settings.py
+++ b/sh_scrapy/settings.py
@@ -88,8 +88,12 @@ def _populate_settings_base(apisettings, defaults_func, spider=None):
 
 
 def _load_default_settings(s):
+    downloader_middlewares = {
+        'sh_scrapy.diskquota.DiskQuotaDownloaderMiddleware': 0,
+    }
     spider_middlewares = {
         'sh_scrapy.extension.HubstorageMiddleware': 0,
+        'sh_scrapy.diskquota.DiskQuotaSpiderMiddleware': 0,
     }
     extensions = {
         'scrapy.extensions.debug.StackTraceDump': 0,
@@ -103,6 +107,7 @@ def _load_default_settings(s):
     else:
         extensions['slybot.closespider.SlybotCloseSpider'] = 0
 
+    s.get('DOWNLOADER_MIDDLEWARES_BASE').update(downloader_middlewares)
     s.get('EXTENSIONS_BASE').update(extensions)
     s.get('SPIDER_MIDDLEWARES_BASE').update(spider_middlewares)
     memory_limit = int(os.environ.get('SHUB_JOB_MEMORY_LIMIT', 950))
@@ -110,6 +115,7 @@ def _load_default_settings(s):
         'STATS_CLASS': 'sh_scrapy.stats.HubStorageStatsCollector',
         'MEMUSAGE_ENABLED': True,
         'MEMUSAGE_LIMIT_MB': memory_limit,
+        'DISK_QUOTA_STOP_ON_ERROR': True,
         'WEBSERVICE_ENABLED': False,
         'LOG_LEVEL': 'INFO',
         'LOG_FILE': 'scrapy.log',

--- a/tests/test_diskquota.py
+++ b/tests/test_diskquota.py
@@ -1,0 +1,73 @@
+import mock
+import pytest
+from scrapy.utils.test import get_crawler
+from scrapy.exceptions import NotConfigured
+
+from sh_scrapy.diskquota import DiskQuota
+from sh_scrapy.diskquota import DiskQuotaDownloaderMiddleware
+from sh_scrapy.diskquota import DiskQuotaSpiderMiddleware
+
+
+def test_disk_quota_disabled():
+    crawler = get_crawler()
+    with pytest.raises(NotConfigured):
+        DiskQuota(crawler)
+
+
+@pytest.fixture
+def crawler():
+    return get_crawler(settings_dict={'DISK_QUOTA_STOP_ON_ERROR': True})
+
+
+def test_disk_quota_init(crawler):
+    dquota = DiskQuota(crawler)
+    assert dquota.crawler == crawler
+
+
+def test_disk_quota_from_crawler(crawler):
+    assert isinstance(DiskQuota.from_crawler(crawler), DiskQuota)
+
+
+def test_disk_quota_check_error(crawler):
+    dquota = DiskQuota(crawler)
+    assert not dquota._is_disk_quota_error(ValueError())
+    assert not dquota._is_disk_quota_error(IOError())
+    valid_error = IOError()
+    valid_error.errno = 122
+    assert dquota._is_disk_quota_error(valid_error)
+
+
+def test_downloaded_mware_process_not_stopped(crawler):
+    crawler.engine = mock.Mock()
+    mware = DiskQuotaDownloaderMiddleware(crawler)
+    mware.process_exception('request', ValueError(), 'spider')
+    assert not crawler.engine.close_spider.called
+
+
+def test_downloaded_mware_process_stopped(crawler):
+    crawler.engine = mock.Mock()
+    mware = DiskQuotaDownloaderMiddleware(crawler)
+    error = IOError()
+    error.errno = 122
+    mware.process_exception('request', error, 'spider')
+    assert crawler.engine.close_spider.called
+    assert crawler.engine.close_spider.call_args[0] == (
+        'spider', 'diskusage_exceeded')
+
+
+def test_spider_mware_process_not_stopped(crawler):
+    crawler.engine = mock.Mock()
+    mware = DiskQuotaSpiderMiddleware(crawler)
+    mware.process_spider_exception('response', ValueError(), 'spider')
+    assert not crawler.engine.close_spider.called
+
+
+def test_spider_mware_process_stopped(crawler):
+    crawler.engine = mock.Mock()
+    mware = DiskQuotaSpiderMiddleware(crawler)
+    error = IOError()
+    error.errno = 122
+    mware.process_spider_exception('response', error, 'spider')
+    assert crawler.engine.close_spider.called
+    assert crawler.engine.close_spider.call_args[0] == (
+        'spider', 'diskusage_exceeded')


### PR DESCRIPTION
The PR adds DiskQuota middlewares enabled by default, they catch IOErrors related with disk quota restrictions and stop a spider.

`DISK_QUOTA_STOP_ON_ERROR` setting - to enable/disable these mwares.

It's an alternative for https://github.com/scrapinghub/scrapinghub-entrypoint-scrapy/pull/17, more lightweight and easy, though with this approach spider can't be stopped gently in advance on X percents of available disk resources. 

Review, please.