### PR TITLE
Bugfix - stop logging to stderr

### DIFF
--- a/sh_scrapy/settings.py
+++ b/sh_scrapy/settings.py
@@ -118,6 +118,7 @@ def _load_default_settings(s):
         'DISK_QUOTA_STOP_ON_ERROR': True,
         'WEBSERVICE_ENABLED': False,
         'LOG_LEVEL': 'INFO',
+        'LOG_ENABLED': False,
         'TELNETCONSOLE_HOST': '0.0.0.0',  # to access telnet console from host
     }, priority='cmdline')
 


### PR DESCRIPTION
#18 introduced a bug - with disabled logging to file Scrapy started logging to stderr and stderr is [redirected](https://github.com/scrapinghub/scrapinghub-entrypoint-scrapy/blob/master/sh_scrapy/log.py#L59) to HubstorageLogHandler. If job is started with new entrypoint version - all logs are duplicated

I tried to fix it by disabling Scrapy logging with `'LOG_ENABLED': False` - with this setting Scrapy setups NullHandler instead of StreamHandler (see [here](https://github.com/scrapy/scrapy/blob/ebef6d7c6dd8922210db8a4a44f48fe27ee0cd16/scrapy/utils/log.py#L113)). It worked for me with local setup, though I wasn't able to test it properly today, so while it works for Python logging I'm not sure if it didn't break stdout/stderr capturing. Also I noticed that one of the warning was missing from job logs - could be another consequence of my change.

In case we want to solve this issue quickly without breaking staff that worked before - we should return `'LOG_FILE': 'scrapy.log'` config and simply silence it by setting the highest `LOG_LEVEL: 'SILENT'`