### PR TITLE
Do not fail on missing addons

### DIFF
--- a/sh_scrapy/settings.py
+++ b/sh_scrapy/settings.py
@@ -21,21 +21,21 @@ except ImportError:
     update_classpath = lambda x: x
 
 
-def _update_settings(o, d, priority='default'):
+def _update_settings(o, changes, priority='default'):
     """
     We need to convert settings to string since the S3 download handler
     doesn't work if the AWS keys are passed as unicode. Other code may also
     depend on settings being str.
 
-    :param o: auxiliary BaseSettings object to merge provided settings
+    :param o: BaseSettings object to merge settings provided by d
     :type o: scrapy.settings.BaseSettings instance
 
-    :param d: final Settings object to run a job
-    :type d: scrapy.settings.Settings instance
+    :param changes: a settings dict to update o with given priority
+    :type changes: a dict
     """
-    for k, v in list(d.items()):
-        d[to_native_str(k)] = to_native_str(v) if is_string(v) else v
-    o.update(d, priority=priority)
+    for k, v in list(changes.items()):
+        changes[to_native_str(k)] = to_native_str(v) if is_string(v) else v
+    o.update(changes, priority=priority)
 
 
 def _maybe_load_autoscraping_project(o, priority=0):

--- a/sh_scrapy/settings.py
+++ b/sh_scrapy/settings.py
@@ -33,7 +33,7 @@ def _update_settings(o, d, priority='default'):
     :param d: final Settings object to run a job
     :type d: scrapy.settings.Settings instance
     """
-    for k, v in d.items():
+    for k, v in list(d.items()):
         d[to_native_str(k)] = to_native_str(v) if is_string(v) else v
     o.update(d, priority=priority)
 

--- a/sh_scrapy/settings.py
+++ b/sh_scrapy/settings.py
@@ -38,20 +38,14 @@ def _update_settings(o, d, priority='default'):
     o.update(d, priority=priority)
 
 
-def _load_autoscraping_settings(s, o):
-    settings = {'ITEM_PIPELINES': {},
-                'SLYDUPEFILTER_ENABLED': True,
-                'SLYCLOSE_SPIDER_ENABLED': True,
-                'SPIDER_MANAGER_CLASS': SLYBOT_SPIDER_MANAGER}
-    for key, value in settings.items():
-        if key not in o:
-            o.set(key, value)
-    o['ITEM_PIPELINES']['slybot.dupefilter.DupeFilterPipeline'] = 0
-
-
-def _maybe_load_autoscraping_project(s, o):
+def _maybe_load_autoscraping_project(s, o, priority=0):
     if os.environ.get('SHUB_SPIDER_TYPE') in ('auto', 'portia'):
-        _load_autoscraping_settings(s, o)
+        settings = {'ITEM_PIPELINES': {},
+                    'SLYDUPEFILTER_ENABLED': True,
+                    'SLYCLOSE_SPIDER_ENABLED': True,
+                    'SPIDER_MANAGER_CLASS': SLYBOT_SPIDER_MANAGER}
+        _update_settings(o, settings, priority=priority)
+        o['ITEM_PIPELINES']['slybot.dupefilter.DupeFilterPipeline'] = 0
         o["PROJECT_ZIPFILE"] = 'project-slybot.zip'
 
 
@@ -112,7 +106,7 @@ def _populate_settings_base(apisettings, defaults_func, spider=None):
     _update_settings(o, organization_settings, priority=20)
     if spider:
         _update_settings(o, spider_settings, priority=30)
-        _maybe_load_autoscraping_project(s, o)
+        _maybe_load_autoscraping_project(s, o, priority=0)
         o['JOBDIR'] = tempfile.mkdtemp(prefix='jobdata-')
     _update_settings(o, job_settings, priority=40)
     # Load addons only after we gather all settings

--- a/sh_scrapy/settings.py
+++ b/sh_scrapy/settings.py
@@ -38,7 +38,7 @@ def _update_settings(o, d, priority='default'):
     o.update(d, priority=priority)
 
 
-def _maybe_load_autoscraping_project(s, o, priority=0):
+def _maybe_load_autoscraping_project(o, priority=0):
     if os.environ.get('SHUB_SPIDER_TYPE') in ('auto', 'portia'):
         settings = {'ITEM_PIPELINES': {},
                     'SLYDUPEFILTER_ENABLED': True,
@@ -106,7 +106,7 @@ def _populate_settings_base(apisettings, defaults_func, spider=None):
     _update_settings(o, organization_settings, priority=20)
     if spider:
         _update_settings(o, spider_settings, priority=30)
-        _maybe_load_autoscraping_project(s, o, priority=0)
+        _maybe_load_autoscraping_project(o, priority=0)
         o['JOBDIR'] = tempfile.mkdtemp(prefix='jobdata-')
     _update_settings(o, job_settings, priority=40)
     # Load addons only after we gather all settings

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -142,21 +142,14 @@ def test_load_addons_void():
     assert settings == o == {}
 
 
-def test_load_addons_no_spider_mwares_setting():
-    addons = [TEST_ADDON]
-    settings, o = Settings(), BaseSettingsWithNativeStrings()
-    _load_addons(addons, settings, o)
-
-
 def test_load_addons_basic_usage():
     addons = [TEST_ADDON]
     settings = BaseSettings({'SPIDER_MIDDLEWARES': {}})
-    o = BaseSettingsWithNativeStrings({'ON_MISSING_ADDONS': 'warn'})
+    o = BaseSettingsWithNativeStrings()
     _load_addons(addons, settings, o)
     assert settings.copy_to_dict() == {'SPIDER_MIDDLEWARES': {
             TEST_ADDON['path']: 10}}
     assert o.copy_to_dict() == {
-        'ON_MISSING_ADDONS': 'warn',
         'SPIDER_MIDDLEWARES': {TEST_ADDON['path']: 10}}
 
 

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -5,7 +5,6 @@ import mock
 import pytest
 from scrapy.settings import BaseSettings, Settings, SettingsAttribute
 from sh_scrapy.settings import _update_settings
-from sh_scrapy.settings import _load_autoscraping_settings
 from sh_scrapy.settings import _maybe_load_autoscraping_project
 from sh_scrapy.settings import _get_component_base
 from sh_scrapy.settings import _get_action_on_missing_addons
@@ -86,29 +85,6 @@ def test_update_settings_check_unicode_in_py3():
     test = BaseSettings({})
     _update_settings(test, {'\xf1e\xf1e\xf1e': 'test'}, 10)
     assert test == {'\xf1e\xf1e\xf1e': 'test'}
-
-
-def test_load_autoscraping_settings_void_settings():
-    settings = BaseSettings({})
-    _load_autoscraping_settings({}, settings)
-    assert settings.copy_to_dict() == {
-        'ITEM_PIPELINES': {'slybot.dupefilter.DupeFilterPipeline': 0},
-        'SLYCLOSE_SPIDER_ENABLED': True,
-        'SLYDUPEFILTER_ENABLED': True,
-        'SPIDER_MANAGER_CLASS':
-            'slybot.spidermanager.ZipfileSlybotSpiderManager'}
-
-
-def test_load_autoscraping_settings_skip_existing():
-    settings = BaseSettings({
-        'SPIDER_MANAGER_CLASS': 'some.class',
-        'SLYDUPEFILTER_ENABLED': False})
-    _load_autoscraping_settings({}, settings)
-    assert settings == {
-        'ITEM_PIPELINES': {'slybot.dupefilter.DupeFilterPipeline': 0},
-        'SLYCLOSE_SPIDER_ENABLED': True,
-        'SLYDUPEFILTER_ENABLED': False,
-        'SPIDER_MANAGER_CLASS': 'some.class'}
 
 
 def test_maybe_load_autoscraping_project_no_spider_type_env():

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -102,7 +102,8 @@ def test_maybe_load_autoscraping_project_custom_type():
 
 @mock.patch.dict(os.environ, {'SHUB_SPIDER_TYPE': 'auto'})
 def test_maybe_load_autoscraping_project_ok():
-    result = BaseSettings({'SPIDER_MANAGER_CLASS': 'test.class'})
+    result = BaseSettingsWithNativeStrings(
+        {'SPIDER_MANAGER_CLASS': 'test.class'})
     _maybe_load_autoscraping_project(result)
     assert result == {
         'ITEM_PIPELINES': {'slybot.dupefilter.DupeFilterPipeline': 0},
@@ -135,7 +136,7 @@ def test_get_action_on_missing_addons_warn_if_wrong_value():
 
 def test_load_addons_void():
     addons = []
-    settings, o = BaseSettings(), BaseSettings()
+    settings, o = BaseSettings(), BaseSettingsWithNativeStrings()
     _load_addons(addons, settings, o)
     assert addons == []
     assert settings == o == {}
@@ -143,14 +144,14 @@ def test_load_addons_void():
 
 def test_load_addons_no_spider_mwares_setting():
     addons = [TEST_ADDON]
-    settings, o = Settings(), BaseSettings()
+    settings, o = Settings(), BaseSettingsWithNativeStrings()
     _load_addons(addons, settings, o)
 
 
 def test_load_addons_basic_usage():
     addons = [TEST_ADDON]
     settings = BaseSettings({'SPIDER_MIDDLEWARES': {}})
-    o = BaseSettings({'ON_MISSING_ADDONS': 'warn'})
+    o = BaseSettingsWithNativeStrings({'ON_MISSING_ADDONS': 'warn'})
     _load_addons(addons, settings, o)
     assert settings.copy_to_dict() == {'SPIDER_MIDDLEWARES': {
             TEST_ADDON['path']: 10}}
@@ -165,7 +166,7 @@ def test_load_addons_basic_with_defaults():
     settings = {'SPIDER_MIDDLEWARES_BASE': {
         'scrapy.spidermiddlewares.httperror.HttpErrorMiddleware': 50,
         'scrapy.spidermiddlewares.offsite.OffsiteMiddleware': 500}}
-    o = BaseSettings({'ON_MISSING_ADDONS': 'warn'})
+    o = BaseSettingsWithNativeStrings({'ON_MISSING_ADDONS': 'warn'})
     _load_addons(addons, settings, o)
     assert settings == {'SPIDER_MIDDLEWARES_BASE': {
         TEST_ADDON['path']: 10,
@@ -182,7 +183,7 @@ def test_load_addons_hworker_fail_on_import():
     addons = [TEST_ADDON.copy()]
     addons[0]['path'] = 'hworker.some.module'
     settings = BaseSettings({'SPIDER_MIDDLEWARES': {}})
-    o = BaseSettings({'ON_MISSING_ADDONS': 'fail'})
+    o = BaseSettingsWithNativeStrings({'ON_MISSING_ADDONS': 'fail'})
     with pytest.raises(ImportError):
         _load_addons(addons, settings, o)
 
@@ -191,7 +192,7 @@ def test_load_addons_hworker_error_on_import():
     addons = [TEST_ADDON.copy()]
     addons[0]['path'] = 'hworker.some.module'
     settings = {'SPIDER_MIDDLEWARES': {}}
-    o = BaseSettings({'ON_MISSING_ADDONS': 'error'})
+    o = BaseSettingsWithNativeStrings({'ON_MISSING_ADDONS': 'error'})
     _load_addons(addons, settings, o)
     assert o.copy_to_dict() == {'ON_MISSING_ADDONS': 'error'}
     assert settings == {'SPIDER_MIDDLEWARES': {}}
@@ -201,7 +202,7 @@ def test_load_addons_hworker_warning_on_import():
     addons = [TEST_ADDON.copy()]
     addons[0]['path'] = 'hworker.some.module'
     settings = {'SPIDER_MIDDLEWARES': {}}
-    o = BaseSettings({'ON_MISSING_ADDONS': 'warn'})
+    o = BaseSettingsWithNativeStrings({'ON_MISSING_ADDONS': 'warn'})
     _load_addons(addons, settings, o)
     assert o.copy_to_dict() == {'ON_MISSING_ADDONS': 'warn'}
     assert settings == {'SPIDER_MIDDLEWARES': {}}
@@ -212,7 +213,7 @@ def test_load_addons_hworker_warning_on_import():
 def test_load_addons_hworker_import_replace():
     addons = [TEST_ADDON]
     settings = {'SPIDER_MIDDLEWARES': {}}
-    o = BaseSettings()
+    o = BaseSettingsWithNativeStrings()
     _load_addons(addons, settings, o)
     assert o.copy_to_dict() == {'SPIDER_MIDDLEWARES': {
         'scrapy.utils.misc.arg_to_iter': 10}}

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -89,21 +89,21 @@ def test_update_settings_check_unicode_in_py3():
 
 def test_maybe_load_autoscraping_project_no_spider_type_env():
     result = {}
-    _maybe_load_autoscraping_project({}, result)
+    _maybe_load_autoscraping_project(result)
     assert result == {}
 
 
 @mock.patch.dict(os.environ, {'SHUB_SPIDER_TYPE': 'custom'})
 def test_maybe_load_autoscraping_project_custom_type():
     result = {}
-    _maybe_load_autoscraping_project({}, result)
+    _maybe_load_autoscraping_project(result)
     assert result == {}
 
 
 @mock.patch.dict(os.environ, {'SHUB_SPIDER_TYPE': 'auto'})
 def test_maybe_load_autoscraping_project_ok():
     result = BaseSettings({'SPIDER_MANAGER_CLASS': 'test.class'})
-    _maybe_load_autoscraping_project({}, result)
+    _maybe_load_autoscraping_project(result)
     assert result == {
         'ITEM_PIPELINES': {'slybot.dupefilter.DupeFilterPipeline': 0},
         'PROJECT_ZIPFILE': 'project-slybot.zip',

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -167,7 +167,7 @@ def test_load_addons_void():
 
 def test_load_addons_no_spider_mwares_setting():
     addons = [TEST_ADDON]
-    settings, o = BaseSettings(), BaseSettings()
+    settings, o = Settings(), BaseSettings()
     _load_addons(addons, settings, o)
 
 

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -4,7 +4,7 @@ import sys
 import mock
 import pytest
 from scrapy.settings import BaseSettings, Settings, SettingsAttribute
-from sh_scrapy.settings import _update_settings
+from sh_scrapy.settings import BaseSettingsWithNativeStrings
 from sh_scrapy.settings import _maybe_load_autoscraping_project
 from sh_scrapy.settings import _get_component_base
 from sh_scrapy.settings import _get_action_on_missing_addons
@@ -32,40 +32,40 @@ TEST_ADDON = {
 
 
 def test_update_settings_void_dictionaries():
-    test = BaseSettings()
-    _update_settings(test, {}, 10)
+    test = BaseSettingsWithNativeStrings()
+    test.update( {}, 10)
     assert test.copy_to_dict() == {}
 
 
 def test_update_settings_base_test():
-    test = BaseSettings()
-    _update_settings(test, {'a': 'b'}, 10)
+    test = BaseSettingsWithNativeStrings()
+    test.update({'a': 'b'}, 10)
     assert test == {'a': 'b'}
 
 
 def test_update_settings_base_test2():
-    test = BaseSettings()
-    _update_settings(test, {'a': 'b', 'c': 'd'}, 10)
+    test = BaseSettingsWithNativeStrings()
+    test.update({'a': 'b', 'c': 'd'}, 10)
     assert test == {'a': 'b', 'c': 'd'}
 
 
 def test_update_settings_dont_fail_on_non_string():
-    test = BaseSettings()
-    _update_settings(test, {'a': 3}, 10)
+    test = BaseSettingsWithNativeStrings()
+    test.update({'a': 3}, 10)
     assert test == {'a': 3}
 
 
 def test_update_settings_update_existing_value():
-    test = BaseSettings({'a': 'b', 'c': 'd'}, priority=10)
-    _update_settings(test, {'c': 'e', 'f': 'g'}, 10)
+    test = BaseSettingsWithNativeStrings({'a': 'b', 'c': 'd'}, priority=10)
+    test.update({'c': 'e', 'f': 'g'}, 10)
     assert test.copy_to_dict() == {'a': 'b', 'c': 'e', 'f': 'g'}
 
 
 @pytest.mark.skipif(sys.version_info[0] == 3, reason="requires python2")
 def test_update_settings_check_unicode_in_py2_key():
     # a dict entry is duplicated as unicode doesn't match native str value
-    test = BaseSettings({})
-    _update_settings(test, {'\xf1e\xf1e\xf1e': 'test'}, 10)
+    test = BaseSettingsWithNativeStrings({})
+    test.update({'\xf1e\xf1e\xf1e': 'test'}, 10)
     assert test == {'\xf1e\xf1e\xf1e': 'test',
                     to_native_str('\xf1e\xf1e\xf1e'): 'test'}
 
@@ -73,8 +73,8 @@ def test_update_settings_check_unicode_in_py2_key():
 @pytest.mark.skipif(sys.version_info[0] == 3, reason="requires python2")
 def test_update_settings_check_unicode_in_py2_key_value():
     # a dict entry is duplicated as unicode doesn't match native str value
-    test = BaseSettings({})
-    _update_settings(test, {'\xf1e\xf1e\xf1e': '\xf1e\xf1e'}, 10)
+    test = BaseSettingsWithNativeStrings({})
+    test.update({'\xf1e\xf1e\xf1e': '\xf1e\xf1e'}, 10)
     assert test == {
         '\xf1e\xf1e\xf1e': '\xf1e\xf1e',
         to_native_str('\xf1e\xf1e\xf1e'): to_native_str('\xf1e\xf1e')}
@@ -82,8 +82,8 @@ def test_update_settings_check_unicode_in_py2_key_value():
 
 @pytest.mark.skipif(sys.version_info < (3,), reason="requires python3")
 def test_update_settings_check_unicode_in_py3():
-    test = BaseSettings({})
-    _update_settings(test, {'\xf1e\xf1e\xf1e': 'test'}, 10)
+    test = BaseSettingsWithNativeStrings({})
+    test.update({'\xf1e\xf1e\xf1e': 'test'}, 10)
     assert test == {'\xf1e\xf1e\xf1e': 'test'}
 
 

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -8,6 +8,7 @@ from sh_scrapy.settings import _update_settings
 from sh_scrapy.settings import _load_autoscraping_settings
 from sh_scrapy.settings import _maybe_load_autoscraping_project
 from sh_scrapy.settings import _get_component_base
+from sh_scrapy.settings import _get_action_on_missing_addons
 from sh_scrapy.settings import _load_addons
 from sh_scrapy.settings import _populate_settings_base
 from sh_scrapy.settings import _load_default_settings
@@ -25,7 +26,7 @@ TEST_ADDON = {
     'default_settings': {},
     'type': 'SPIDER_MIDDLEWARES',
     'order': 10,
-    'path': 'some.addon.path',
+    'path': 'scrapy.spidermiddlewares.SomeExistingMware',
     'builtin': False,
     'needs_aws': False,
 }
@@ -140,10 +141,30 @@ def test_get_component_base():
     assert _get_component_base({'TEST_BASE': 'VAL'}, 'TEST') == 'TEST_BASE'
 
 
+def test_get_action_on_missing_addons_default():
+    assert _get_action_on_missing_addons([]) == 'warn'
+
+
+def test_get_action_on_missing_addons_base():
+    assert _get_action_on_missing_addons(
+        [{'ON_MISSING_ADDONS': 'fail'}]) == 'fail'
+
+
+def test_get_action_on_missing_addons_first_matter():
+    assert _get_action_on_missing_addons(
+        [{'ON_MISSING_ADDONS': 'fail'},
+         {'ON_MISSING_ADDONS': 'error'}]) == 'fail'
+
+
+def test_get_action_on_missing_addons_warn_if_wrong_value():
+    assert _get_action_on_missing_addons(
+        [{'ON_MISSING_ADDONS': 'wrong'}]) == 'warn'
+
+
 def test_load_addons_void():
     addons = []
     settings = o = {}
-    _load_addons(addons, settings, o)
+    _load_addons(addons, settings, o, 'warn')
     assert addons == []
     assert settings == o == {}
 
@@ -152,7 +173,7 @@ def test_load_addons_no_spider_mwares_setting():
     addons = [TEST_ADDON]
     settings = o = {}
     with pytest.raises(KeyError) as excinfo:
-        _load_addons(addons, settings, o)
+        _load_addons(addons, settings, o, 'warn')
     assert 'SPIDER_MIDDLEWARES' in str(excinfo.value)
 
 
@@ -160,8 +181,9 @@ def test_load_addons_basic_usage():
     addons = [TEST_ADDON]
     settings = {'SPIDER_MIDDLEWARES': {}}
     o = {}
-    _load_addons(addons, settings, o)
-    assert settings == o == {'SPIDER_MIDDLEWARES': {'some.addon.path': 10}}
+    _load_addons(addons, settings, o, 'warn')
+    assert settings == o == {'SPIDER_MIDDLEWARES': {
+        'scrapy.spidermiddlewares.SomeExistingMware': 10}}
 
 
 def test_load_addons_basic_with_defaults():
@@ -171,34 +193,54 @@ def test_load_addons_basic_with_defaults():
         'scrapy.spidermiddlewares.httperror.HttpErrorMiddleware': 50,
         'scrapy.spidermiddlewares.offsite.OffsiteMiddleware': 500}}
     o = {}
-    _load_addons(addons, settings, o)
+    _load_addons(addons, settings, o, 'warn')
     assert settings == {'SPIDER_MIDDLEWARES_BASE': {
         'scrapy.spidermiddlewares.httperror.HttpErrorMiddleware': 50,
         'scrapy.spidermiddlewares.offsite.OffsiteMiddleware': 500,
-        'some.addon.path': 10}}
+        'scrapy.spidermiddlewares.SomeExistingMware': 10}}
     expected_o = settings.copy()
     expected_o['TEST_SETTING_A'] = 'TEST'
     assert o == expected_o
 
 
-def test_load_addons_hworker_import_ignore():
+def test_load_addons_hworker_fail_on_import():
+    addons = [TEST_ADDON.copy()]
+    addons[0]['path'] = 'hworker.some.module'
+    settings = {'SPIDER_MIDDLEWARES': {}}
+    with pytest.raises(ImportError):
+        _load_addons(addons, settings, {}, 'fail')
+
+
+def test_load_addons_hworker_error_on_import():
     addons = [TEST_ADDON.copy()]
     addons[0]['path'] = 'hworker.some.module'
     settings = {'SPIDER_MIDDLEWARES': {}}
     o = {}
-    _load_addons(addons, settings, o)
-    assert settings == {'SPIDER_MIDDLEWARES': {}}
+    _load_addons(addons, settings, o, 'error')
     assert o == {}
+    assert settings == {'SPIDER_MIDDLEWARES': {}}
 
 
+def test_load_addons_hworker_warning_on_import():
+    addons = [TEST_ADDON.copy()]
+    addons[0]['path'] = 'hworker.some.module'
+    settings = {'SPIDER_MIDDLEWARES': {}}
+    o = {}
+    _load_addons(addons, settings, o, 'warn')
+    assert o == {}
+    assert settings == {'SPIDER_MIDDLEWARES': {}}
+
+
+@mock.patch.dict('sh_scrapy.settings.REPLACE_ADDONS_PATHS',
+                 {'scrapy.spidermiddlewares.SomeExistingMware':
+                     'scrapy.spidermiddlewares.NewPath'})
 def test_load_addons_hworker_import_replace():
-    for addon_path, replace_path in REPLACE_ADDONS_PATHS.items():
-        addons = [TEST_ADDON.copy()]
-        addons[0]['path'] = addon_path
-        settings = {'SPIDER_MIDDLEWARES': {}}
-        o = {}
-        _load_addons(addons, settings, o)
-        assert settings == o == {'SPIDER_MIDDLEWARES': {replace_path: 10}}
+    addons = [TEST_ADDON]
+    settings = {'SPIDER_MIDDLEWARES': {}}
+    o = {}
+    _load_addons(addons, settings, o, 'warn')
+    assert settings == o == {'SPIDER_MIDDLEWARES': {
+        'scrapy.spidermiddlewares.NewPath': 10}}
 
 
 def test_populate_settings_dont_fail():


### PR DESCRIPTION
For now if there's some missing module for one of the addons, job init process will fail with an import error. The idea behind this PR is to make it configurable and allow to set correct behaviour via settings.

There's a new `ON_MISSING_ADDONS` setting with allowed values:
- `fail` - the previous behaviour, just fail with import error
- `warn` - log an import error as a warning, and skip it
- `error` - log an import error as an error, and skip it

The load addons step happens after we setup logging system, so it's fine to use standard python `logging` here, like [scrapy.log](https://github.com/scrapy/scrapy/blob/1.0.5/scrapy/log.py#L40) proposes.

Review, please.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/scrapinghub/scrapinghub-entrypoint-scrapy/21)
<!-- Reviewable:end -->
