### PR TITLE
Better handling of settings with inner dicts

### DIFF
--- a/sh_scrapy/settings.py
+++ b/sh_scrapy/settings.py
@@ -17,6 +17,13 @@ REPLACE_ADDONS_PATHS = {
 }
 SLYBOT_SPIDER_MANAGER = 'slybot.spidermanager.ZipfileSlybotSpiderManager'
 SLYBOT_DUPE_FILTER = 'slybot.dupefilter.DupeFilterPipeline'
+SETTINGS_ORDERED_DICTS = [
+    "DOWNLOADER_MIDDLEWARES", "DOWNLOADER_MIDDLEWARES_BASE",
+    "EXTENSIONS", "EXTENSIONS_BASE",
+    "ITEM_PIPELINES", "ITEM_PIPELINES_BASE",
+    "SPIDER_CONTRACTS", "SPIDER_CONTRACTS_BASE",
+    "SPIDER_MIDDLEWARES", "SPIDER_MIDDLEWARES_BASE"
+]
 
 try:
     from scrapy.utils.deprecate import update_classpath
@@ -130,9 +137,12 @@ def _merge_with_keeping_order(settings, updates):
         if not isinstance(value, dict):
             settings.set(setting_key, value, priority='cmdline')
             continue
-        components = settings[setting_key]
-        for path, order in value.items():
-            _update_component_order(components, path, order)
+        if setting_key in SETTINGS_ORDERED_DICTS:
+            components = settings[setting_key]
+            for path, order in value.items():
+                _update_component_order(components, path, order)
+        else:
+            settings.set(setting_key, value)
 
 
 def _populate_settings_base(apisettings, defaults_func, spider=None):

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -324,6 +324,13 @@ def test_populate_settings_keep_user_priorities(get_settings_mock):
         'scrapy.utils.misc.load_object'] == 1
 
 
+def test_populate_settings_unique_update_dict():
+    monitoring_dict = {u'SPIDER_OPENED': {u'failed_actions': []}}
+    msg = {'spider_settings': {'DASH_MONITORING': monitoring_dict}}
+    result = _populate_settings_base(msg, lambda x: x, spider=True)
+    assert result['DASH_MONITORING'] == monitoring_dict
+
+
 @mock.patch('sh_scrapy.settings.get_project_settings')
 def test_populate_settings_keep_user_priorities_oldpath(get_settings_mock):
     get_settings_mock.return_value = Settings({


### PR DESCRIPTION
For now every diction in settings is considered as a dict with ordered paths and handled appropriately. However there're some other cases when there's a custom setting with a dict of arbitrary nesting, we should handle it properly.

Review, please.