### PR TITLE
Check if distribution found for scripts

### DIFF
--- a/sh_scrapy/crawl.py
+++ b/sh_scrapy/crawl.py
@@ -27,6 +27,20 @@ _sentry_dsn = os.environ.pop('SENTRY_DSN', _hworker_sentry_dsn)
 socket.setdefaulttimeout(60.0)
 
 
+SCRAPY_SETTINGS_ENTRYPOINT_NOT_FOUND = """
+Scrapy distribution with `scrapy.settings` entrypoint is not found.
+The entrypoint should be specified in your project setup.py, please make sure
+you specified it in the following format:
+setup(
+    ...,
+    entry_points = {'scrapy': ['settings = your_project.settings']},
+    ...
+)
+Check the link for more details:
+https://setuptools.readthedocs.io/en/latest/pkg_resources.html#entry-points
+"""
+
+
 @contextmanager
 def ignore_warnings(**kwargs):
     """Context manager that creates a temporary filter to ignore warnings.
@@ -109,6 +123,8 @@ def _run_pkgscript(argv):
             if ep.name == 'settings':
                 return ep.dist
     d = get_distribution()
+    if not d:
+        raise ValueError(SCRAPY_SETTINGS_ENTRYPOINT_NOT_FOUND)
     d.run_script(scriptname, {'__name__': '__main__'})
 
 

--- a/tests/test_crawl.py
+++ b/tests/test_crawl.py
@@ -120,6 +120,15 @@ def test_run_pkg_script(run_pkg_mock):
     assert run_pkg_mock.call_args[0] == (['py:script.py'],)
 
 
+@mock.patch('pkg_resources.WorkingSet')
+def test_run_pkg_script_distribution_not_found(working_set_class):
+    fake_set = mock.Mock()
+    fake_set.iter_entry_points.return_value = iter(())
+    working_set_class.return_value = fake_set
+    with pytest.raises(ValueError):
+        _run(['py:script.py'], {'SETTING': 'VALUE'})
+
+
 @mock.patch('sh_scrapy.crawl._run_scrapy')
 def test_run_scrapy_spider(run_scrapy_mock):
     _run(['scrapy', 'crawl', 'spider'], {'SETTING': 'VALUE'})


### PR DESCRIPTION
We should check if there's a distribution before trying to run a script, and print an appropriate error message if it's not found (and what's the possible reason of it).

Review, please.