### PR TITLE
Do not update classpaths in config for non-string keys

### DIFF
--- a/sh_scrapy/settings.py
+++ b/sh_scrapy/settings.py
@@ -84,7 +84,12 @@ def _get_action_on_missing_addons(settings):
 
 
 def _update_old_classpaths(settings):
-    """Update user's project settings with proper class paths"""
+    """Update user's project settings with proper class paths.
+
+    Note that the method updates only settings with dicts as values:
+    it's needed for proper dicts merge to avoid duplicates in paths.
+    For all other cases Scrapy will handle it by itself.
+    """
     for setting_key in settings.attributes.keys():
         setting_value = settings[setting_key]
         # A workaround to make it work for:
@@ -95,6 +100,8 @@ def _update_old_classpaths(settings):
         elif not isinstance(setting_value, dict):
             continue
         for path in setting_value.keys():
+            if not is_string(path):
+                continue
             updated_path = update_classpath(path)
             if updated_path != path:
                 order = settings[setting_key].pop(path)

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -12,6 +12,7 @@ from sh_scrapy.settings import _get_action_on_missing_addons
 from sh_scrapy.settings import _load_addons
 from sh_scrapy.settings import _populate_settings_base
 from sh_scrapy.settings import _load_default_settings
+from sh_scrapy.settings import _update_old_classpaths
 from sh_scrapy.settings import populate_settings
 from sh_scrapy.settings import REPLACE_ADDONS_PATHS
 
@@ -380,3 +381,19 @@ def test_populate_settings_dont_fail_with_spider():
     assert isinstance(result, Settings)
     # check one of the settings provided by default by sh_scrapy
     assert result['TELNETCONSOLE_HOST'] == '0.0.0.0'
+
+
+def test_update_old_classpaths_not_string():
+
+    class CustomObject(object):
+        pass
+
+    test_value = {'scrapy.contrib.exporter.CustomExporter': 1,
+                  123: 2, CustomObject: 3}
+    test_settings = Settings({'SOME_SETTING': test_value})
+    _update_old_classpaths(test_settings)
+    expected = test_settings['SOME_SETTING'].keys()
+    assert len(expected) == 3
+    assert 123 in expected
+    assert CustomObject in expected
+    assert 'scrapy.exporters.CustomExporter' in expected


### PR DESCRIPTION
Skip `update-classpath` logic if dict key is not a string.

Review, please.