### PR TITLE
Replace py-hubstorage with py-scrapinghub

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ setup(
     packages=find_packages(),
     install_requires=[
         'Scrapy>=1.0',
-        'hubstorage>=0.23.2',
+        'scrapinghub>=1.9.0',
     ],
     entry_points={
         'console_scripts': [

--- a/sh_scrapy/hsref.py
+++ b/sh_scrapy/hsref.py
@@ -44,7 +44,7 @@ class _HubstorageRef(object):
 
     @property
     def client(self):
-        from hubstorage.client import HubstorageClient
+        from scrapinghub import HubstorageClient
         if self._client is None:
             user_agent = os.environ.get('SHUB_HS_USER_AGENT')
             self._client = HubstorageClient(endpoint=self.endpoint,

--- a/tests/test_hsref.py
+++ b/tests/test_hsref.py
@@ -30,7 +30,7 @@ def hsref():
 @pytest.fixture
 def hsc_class(monkeypatch):
     hsc_class = mock.Mock()
-    monkeypatch.setattr('hubstorage.client.HubstorageClient', hsc_class)
+    monkeypatch.setattr('scrapinghub.HubstorageClient', hsc_class)
     return hsc_class
 
 


### PR DESCRIPTION
As python-hubstorage is deprecated, let's replace it with python-scrapinghub.

Review, please.