### PR TITLE
Update entrypoint to use new Scrapinghub interface

### DIFF
--- a/sh_scrapy/crawl.py
+++ b/sh_scrapy/crawl.py
@@ -159,8 +159,6 @@ def _launch():
         args, env = get_args_and_env(job)
         os.environ.update(env)
 
-        print(args, env)
-
         from sh_scrapy.log import initialize_logging
         from sh_scrapy.settings import populate_settings  # NOQA
         from sh_scrapy.env import setup_environment
@@ -190,15 +188,26 @@ def list_spiders():
 
 def main():
     try:
+        from sh_scrapy.writer import pipe_writer
+    except Exception:
+        _fatalerror()
+        return 1
+    try:
         _launch()
+    except SystemExit as e:
+        return e.code
+    except:
+        # exception was already handled and logged inside _launch()
+        return 1
     finally:
         sys.stderr = _sys_stderr
         sys.stdout = _sys_stdout
         try:
-            from sh_scrapy.hsref import hsref
-            hsref.close()
+            pipe_writer.close()
         except Exception:
             _fatalerror()
+            return 1
+    return 0
 
 
 if __name__ == '__main__':

--- a/sh_scrapy/settings.py
+++ b/sh_scrapy/settings.py
@@ -161,7 +161,7 @@ def _populate_settings_base(apisettings, defaults_func, spider=None):
     changing a dict in merged settings means mutating it in original settings.
     """
     assert 'scrapy.conf' not in sys.modules, "Scrapy settings already loaded"
-    settings = get_project_settings()
+    settings = get_project_settings().copy()
     _update_old_classpaths(settings)
     merged_settings = EntrypointSettings()
 

--- a/sh_scrapy/writer.py
+++ b/sh_scrapy/writer.py
@@ -1,0 +1,63 @@
+# -*- coding: utf-8 -*-
+import json
+import os
+import threading
+
+from scrapinghub.hubstorage.serialization import jsondefault
+from scrapinghub.hubstorage.utils import millitime
+
+
+class _PipeWriter(object):
+
+    def __init__(self, path):
+        self.path = path
+        self._pipe = open(self.path, 'w')
+        self._lock = threading.Lock()
+
+    def _write(self, command, payload):
+        # write needs to be locked because write can be called from multiple threads
+        encoded_payload = json.dumps(payload,
+                                     separators=(',', ':'),
+                                     default=jsondefault)
+        with self._lock:
+            self._pipe.write(command)
+            self._pipe.write(' ')
+            self._pipe.write(encoded_payload)
+            self._pipe.write('\n')
+            self._pipe.flush()
+
+    def write_log(self, level, message):
+        log = {
+            'time': millitime(),
+            'level': level,
+            'message': message
+        }
+        self._write('LOG', log)
+
+    def write_request(self, url, status, method, rs, duration, parent, fp):
+        request = {
+            'url': url,
+            'status': int(status),
+            'method': method,
+            'rs': int(rs),
+            'duration': int(duration),
+            'parent': parent,
+            'time': millitime(),
+            'fp': fp,
+        }
+        self._write('REQ', request)
+
+    def write_item(self, item):
+        self._write('ITM', item)
+
+    def write_stats(self, stats):
+        self._write('STA', {'time': millitime(), 'stats': stats})
+
+    def set_outcome(self, outcome):
+        self._write('FIN', {'outcome': outcome})
+
+    def close(self):
+        self._pipe.close()
+
+
+pipe_writer = _PipeWriter(os.environ['SHUB_FIFO_PATH'])

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,32 @@
+# -*- coding: utf-8 -*-
+import codecs
+import os
+import shutil
+import tempfile
+
+import pytest
+
+TEMP_DIR = tempfile.mkdtemp()
+SHUB_FIFO_PATH = os.path.join(TEMP_DIR, 'scrapinghub')
+os.environ['SHUB_FIFO_PATH'] = SHUB_FIFO_PATH
+
+from sh_scrapy.compat import to_native_str, to_bytes
+
+TEST_AUTH = to_native_str(codecs.encode(to_bytes('1/2/3:authstr'), 'hex_codec'))
+
+
+@pytest.fixture(scope='session', autouse=True)
+def clean_shub_fifo_path():
+    global TEMP_DIR
+    try:
+        yield
+    finally:
+        shutil.rmtree(TEMP_DIR)
+
+
+@pytest.fixture(autouse=True)
+def set_jobkeyenvironment(monkeypatch):
+    monkeypatch.setenv('SHUB_JOBKEY', '1/2/3')
+    monkeypatch.setenv('SCRAPY_JOB', '1/2/3')
+    monkeypatch.setenv('SHUB_JOBAUTH', TEST_AUTH)
+    monkeypatch.setenv('SHUB_STORAGE', 'storage-url')

--- a/tests/test_compat.py
+++ b/tests/test_compat.py
@@ -1,7 +1,5 @@
-import sys
 import pytest
 from sh_scrapy.compat import to_bytes
-from sh_scrapy.compat import to_native_str
 from sh_scrapy.compat import to_unicode
 
 # Testing to_unicode conversion

--- a/tests/test_crawl.py
+++ b/tests/test_crawl.py
@@ -274,22 +274,22 @@ def test_list_spiders_handle_fatalerror(mocked_setup, mocked_fatalerr):
     assert mocked_fatalerr.called
 
 
-@mock.patch('sh_scrapy.hsref.hsref')
+@mock.patch('sh_scrapy.writer.pipe_writer')
 @mock.patch('sh_scrapy.crawl._launch')
-def test_main(mocked_launch, hsref):
+def test_main(mocked_launch, pipe_writer):
     main()
     assert mocked_launch.called
     assert mocked_launch.call_args == ()
     assert sys.stdout == sh_scrapy.crawl._sys_stdout
     assert sys.stderr == sh_scrapy.crawl._sys_stderr
-    assert hsref.close.called
+    assert pipe_writer.close.called
 
 
 @mock.patch('sh_scrapy.crawl._fatalerror')
-@mock.patch('sh_scrapy.hsref.hsref')
+@mock.patch('sh_scrapy.writer.pipe_writer')
 @mock.patch('sh_scrapy.crawl._launch')
-def test_main_dont_fail_if_not_hsref(mocked_launch, hsref, mocked_fatalerr):
-    hsref.close.side_effect = IOError('connection error')
+def test_main_log_fatal_error_if_pipe_close_fails(mocked_launch, pipe_writer, mocked_fatalerr):
+    pipe_writer.close.side_effect = IOError('some error while closing pipe')
     main()
     assert mocked_launch.called
     assert mocked_launch.call_args == ()

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -14,7 +14,6 @@ from sh_scrapy.settings import _populate_settings_base
 from sh_scrapy.settings import _load_default_settings
 from sh_scrapy.settings import _update_old_classpaths
 from sh_scrapy.settings import populate_settings
-from sh_scrapy.settings import REPLACE_ADDONS_PATHS
 
 from sh_scrapy.compat import to_native_str
 

--- a/tests/test_stats.py
+++ b/tests/test_stats.py
@@ -8,33 +8,22 @@ from sh_scrapy import stats
 
 
 @pytest.fixture
-@mock.patch('sh_scrapy.hsref.hsref')
-def collector(hsref):
+def collector(monkeypatch):
+    monkeypatch.setattr('sh_scrapy.stats.pipe_writer', mock.Mock())
     crawler = get_crawler(Spider)
     return stats.HubStorageStatsCollector(crawler)
 
 
 def test_collector_class_vars(collector):
-    assert collector.STATS_TO_COLLECT == [
-        'item_scraped_count',
-        'response_received_count',
-        'scheduler/enqueued',
-        'scheduler/dequeued',
-        'log_count/ERROR',
-    ]
     assert collector.INTERVAL == 30
 
 
 def test_collector_upload_stats(collector):
-    collector.set_stats({'item_scraped_count': 10, 'scheduler/enqueued': 20})
+    stats = {'item_scraped_count': 10, 'scheduler/enqueued': 20}
+    collector.set_stats(stats.copy())
     collector._upload_stats()
-    assert collector.hsref.job.samples.write.call_count == 1
-    samples_args = collector.hsref.job.samples.write.call_args[0][0]
-    assert isinstance(samples_args[0], int)
-    assert samples_args[1:] == [10, 0, 20, 0, 0]
-    collector.hsref.job.metadata.apipost.assert_called_with(
-        jl={'scrapystats': {'item_scraped_count': 10,
-                            'scheduler/enqueued': 20}})
+    assert collector.pipe_writer.write_stats.call_count == 1
+    collector.pipe_writer.write_stats.assert_called_with(stats.copy())
 
 
 @mock.patch('twisted.internet.task.LoopingCall')
@@ -50,8 +39,8 @@ def test_collector_open_spider(lcall, collector):
 def test_collector_close_spider(collector):
     collector._samplestask = mock.Mock()
     collector._samplestask.running = True
-    collector.set_stats({'item_scraped_count': 10})
+    stats = {'item_scraped_count': 10}
+    collector.set_stats(stats.copy())
     collector.close_spider('spider', 'reason')
     assert collector._samplestask.stop.called
-    collector.hsref.job.metadata.apipost.assert_called_with(
-        jl={'scrapystats': {'item_scraped_count': 10}})
+    collector.pipe_writer.write_stats.assert_called_with(stats.copy())

--- a/tests/test_writer.py
+++ b/tests/test_writer.py
@@ -1,0 +1,134 @@
+# -*- coding: utf-8 -*-
+import json
+import logging
+import os
+import threading
+
+from six.moves.queue import Queue
+import pytest
+
+from sh_scrapy.writer import _PipeWriter
+
+
+@pytest.fixture
+def fifo(tmpdir):
+    path = os.path.join(str(tmpdir.mkdir('fifo')), 'scrapinghub')
+    os.mkfifo(path)
+    return path
+
+
+@pytest.fixture
+def queue():
+    return Queue()
+
+
+@pytest.fixture
+def reader(fifo, queue):
+    def read_from_fifo():
+        with open(fifo) as f:
+            for line in iter(f.readline, ''):
+                queue.put(line)
+
+    reader_thread = threading.Thread(target=read_from_fifo)
+    reader_thread.start()
+    try:
+        yield reader_thread
+    finally:
+        reader_thread.join(timeout=1)
+
+
+@pytest.fixture
+def writer(fifo, reader):
+    w = _PipeWriter(fifo)
+    try:
+        yield w
+    finally:
+        w.close()
+
+
+def test_close(writer):
+    assert writer._pipe.closed is False
+    writer.close()
+    assert writer._pipe.closed is True
+
+
+def _parse_data_line(msg):
+    assert msg.endswith('\n')
+    cmd, _, payload = msg.strip().partition(' ')
+    return cmd, json.loads(payload)
+
+
+def test_write_item(writer, queue):
+    writer.write_item({'foo': 'bar'})
+    line = queue.get(timeout=1)
+    assert queue.empty()
+    cmd, payload = _parse_data_line(line)
+    assert cmd == 'ITM'
+    assert payload == {'foo': 'bar'}
+
+
+def test_write_request(writer, queue):
+    writer.write_request(
+        url='http://example.com/',
+        status=200,
+        method='GET',
+        rs=1024,
+        duration=102,
+        parent=None,
+        fp='fingerprint',
+    )
+    line = queue.get(timeout=1)
+    assert queue.empty()
+    cmd, payload = _parse_data_line(line)
+    assert cmd == 'REQ'
+    assert isinstance(payload.pop('time'), int)
+    assert payload == {
+        'url': 'http://example.com/',
+        'status': 200,
+        'method': 'GET',
+        'rs': 1024,
+        'duration': 102,
+        'parent': None,
+        'fp': 'fingerprint',
+    }
+
+
+def test_write_log(writer, queue):
+    writer.write_log(
+        level=logging.INFO,
+        message='text',
+    )
+    line = queue.get(timeout=1)
+    assert queue.empty()
+    cmd, payload = _parse_data_line(line)
+    assert cmd == 'LOG'
+    assert isinstance(payload.pop('time'), int)
+    assert payload == {
+        'message': 'text',
+        'level': logging.INFO
+    }
+
+
+def test_write_stats(writer, queue):
+    stats = {'item_scraped_count': 10, 'scheduler/enqueued': 20}
+    writer.write_stats(stats.copy())
+    line = queue.get(timeout=1)
+    assert queue.empty()
+    cmd, payload = _parse_data_line(line)
+    assert cmd == 'STA'
+    assert isinstance(payload.pop('time'), int)
+    assert payload == {
+        'stats': stats.copy()
+    }
+
+
+def test_set_outcome(writer, queue):
+    outcome = 'custom_outcome'
+    writer.set_outcome(outcome)
+    line = queue.get(timeout=1)
+    assert queue.empty()
+    cmd, payload = _parse_data_line(line)
+    assert cmd == 'FIN'
+    assert payload == {
+        'outcome': outcome
+    }

--- a/tox.ini
+++ b/tox.ini
@@ -8,6 +8,7 @@ deps =
     pytest-cov
     mock
     hubstorage
+    six
     py27-scrapy105: Scrapy==1.0.5
 commands =
     py.test --cov=sh_scrapy --cov-report=


### PR DESCRIPTION
Use named pipe located in the job container to send data to Scrapinghub
backend.