### PR TITLE
Update path to Deltafetch addon

### DIFF
--- a/sh_scrapy/settings.py
+++ b/sh_scrapy/settings.py
@@ -14,6 +14,8 @@ REPLACE_ADDONS_PATHS = {
         "scrapy_pagestorage.PageStorageMiddleware",
     "hworker.bot.ext.persistence.DotScrapyPersistence":
         "scrapy_dotpersistence.DotScrapyPersistence",
+    "scrapylib.deltafetch.DeltaFetch":
+        "scrapy_deltafetch.middleware.DeltaFetch",
 }
 SLYBOT_SPIDER_MANAGER = 'slybot.spidermanager.ZipfileSlybotSpiderManager'
 SLYBOT_DUPE_FILTER = 'slybot.dupefilter.DupeFilterPipeline'


### PR DESCRIPTION
Scrapylib version of `deltafetch` addon is pretty outdated, the goal of the change is to replace its path with latest `scrapy-plugins/scrapy-deltafetch` path if the addon is enabled (or warn if it doesn't exist). In addition to the change, we should add `scrapy-deltafetch` dependency to all the latest versions of stacks.