### PR TITLE
Instantiate pipe_writer even if environment is not set

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -10,6 +10,7 @@ setup(
     install_requires=[
         'Scrapy>=1.0',
         'scrapinghub>=1.9.0',
+        'six>=1.5.2',
     ],
     entry_points={
         'console_scripts': [

--- a/tox.ini
+++ b/tox.ini
@@ -8,7 +8,7 @@ deps =
     pytest-cov
     mock
     hubstorage
-    six
+    six>=1.5.2
     py27-scrapy105: Scrapy==1.0.5
 commands =
     py.test --cov=sh_scrapy --cov-report=


### PR DESCRIPTION
If pipe path is not set in the environment - replace pipe with a StringIO object and raise a warning.

Alternative to #38