### PR TITLE
Disk quotas can also raise OSError

### DIFF
--- a/sh_scrapy/diskquota.py
+++ b/sh_scrapy/diskquota.py
@@ -18,7 +18,7 @@ class DiskQuota(object):
         return cls(crawler)
 
     def _is_disk_quota_error(self, error):
-        return isinstance(error, IOError) and error.errno == 122
+        return isinstance(error, (OSError, IOError)) and error.errno == 122
 
 
 class DiskQuotaDownloaderMiddleware(DiskQuota):

--- a/tests/test_diskquota.py
+++ b/tests/test_diskquota.py
@@ -35,6 +35,9 @@ def test_disk_quota_check_error(crawler):
     valid_error = IOError()
     valid_error.errno = 122
     assert dquota._is_disk_quota_error(valid_error)
+    other_valid_error = OSError()
+    other_valid_error.errno = 122
+    assert dquota._is_disk_quota_error(other_valid_error)
 
 
 def test_downloaded_mware_process_not_stopped(crawler):


### PR DESCRIPTION
Sometimes disk quota lead to similar `OSError` (`OSError: [Errno 122] Disk quota exceeded`), we should handle it properly in the same way. 

The difference could be related with python version, I've seen such errors for Python 3 (one of the cases when it happens is [HttpCacheMiddleware](https://github.com/scrapy/scrapy/blob/master/scrapy/downloadermiddlewares/httpcache.py#L106) trying to cache response).