### PR TITLE
Store all performed requests in the Hubstorage

### DIFF
--- a/sh_scrapy/exceptions.py
+++ b/sh_scrapy/exceptions.py
@@ -1,0 +1,7 @@
+# -*- coding: utf-8 -*-
+
+
+class SHScrapyDeprecationWarning(Warning):
+    """Warning category for deprecated features, since the default
+    DeprecationWarning is silenced on Python 2.7+
+    """

--- a/sh_scrapy/middlewares.py
+++ b/sh_scrapy/middlewares.py
@@ -1,0 +1,76 @@
+# -*- coding: utf-8 -*-
+import itertools
+from weakref import WeakKeyDictionary
+
+from scrapy import Request
+from scrapy.utils.request import request_fingerprint
+
+from sh_scrapy.writer import pipe_writer
+
+HS_REQUEST_ID_KEY = '_hsid'
+HS_PARENT_ID_KEY = '_hsparent'
+request_id_sequence = itertools.count()
+seen_requests = WeakKeyDictionary()
+
+
+class HubstorageSpiderMiddleware(object):
+    """Hubstorage spider middleware.
+    
+    What it does:
+    
+    - Sets parent request ids to the requests coming out of the spider.
+    
+    """
+
+    def __init__(self):
+        self._seen_requests = seen_requests
+
+    def process_spider_output(self, response, result, spider):
+        parent = self._seen_requests.pop(response.request, None)
+        for x in result:
+            if isinstance(x, Request):
+                x.meta[HS_PARENT_ID_KEY] = parent
+                # Remove request id if it was for some reason set in the request coming from Spider.
+                x.meta.pop(HS_REQUEST_ID_KEY, None)
+            yield x
+
+
+class HubstorageDownloaderMiddleware(object):
+    """Hubstorage dowloader middleware.
+    
+    What it does:
+    
+    - Generates request ids for all downloaded requests.
+    - Sets parent request ids for requests generated in downloader middlewares.
+    - Stores all downloaded requests into Hubstorage.
+    
+    """
+
+    def __init__(self):
+        self._seen_requests = seen_requests
+        self.pipe_writer = pipe_writer
+        self.request_id_sequence = request_id_sequence
+
+    def process_request(self, request, spider):
+        # Check if request id is set, which usually happens for retries or redirects because
+        # those requests are usually copied from the original one.
+        request_id = request.meta.pop(HS_REQUEST_ID_KEY, None)
+        if request_id is not None:
+            # Set original request id or None as a parent request id.
+            request.meta[HS_PARENT_ID_KEY] = request_id
+
+    def process_response(self, request, response, spider):
+        self.pipe_writer.write_request(
+            url=response.url,
+            status=response.status,
+            method=request.method,
+            rs=len(response.body),
+            duration=request.meta.get('download_latency', 0) * 1000,
+            parent=request.meta.setdefault(HS_PARENT_ID_KEY),
+            fp=request_fingerprint(request),
+        )
+        # Generate and set request id.
+        request_id = next(self.request_id_sequence)
+        self._seen_requests[request] = request_id
+        request.meta[HS_REQUEST_ID_KEY] = request_id
+        return response

--- a/sh_scrapy/settings.py
+++ b/sh_scrapy/settings.py
@@ -189,11 +189,12 @@ def _populate_settings_base(apisettings, defaults_func, spider=None):
 
 def _load_default_settings(settings):
     downloader_middlewares = {
-        'sh_scrapy.diskquota.DiskQuotaDownloaderMiddleware': 0,
+        'sh_scrapy.diskquota.DiskQuotaDownloaderMiddleware': -10000,  # closest to the engine
+        'sh_scrapy.middlewares.HubstorageDownloaderMiddleware': 10000,  # closest to the downloader
     }
     spider_middlewares = {
-        'sh_scrapy.extension.HubstorageMiddleware': 0,
-        'sh_scrapy.diskquota.DiskQuotaSpiderMiddleware': 0,
+        'sh_scrapy.diskquota.DiskQuotaSpiderMiddleware': -10001,  # closest to the engine
+        'sh_scrapy.middlewares.HubstorageSpiderMiddleware': -10000,  # right after disk quota middleware
     }
     extensions = {
         'scrapy.extensions.debug.StackTraceDump': 0,

--- a/tests/test_extension.py
+++ b/tests/test_extension.py
@@ -1,16 +1,17 @@
 import sys
+from weakref import WeakKeyDictionary
+
 import mock
 import pytest
-from weakref import WeakKeyDictionary
+from scrapy import Spider
+from scrapy.exporters import PythonItemExporter
 from scrapy.http import Request, Response
 from scrapy.item import Item
-from scrapy import Spider
-from scrapy.utils.test import get_crawler
-from scrapy.exporters import PythonItemExporter
 from scrapy.utils.request import request_fingerprint
+from scrapy.utils.test import get_crawler
 
-from sh_scrapy.extension import HubstorageExtension
-from sh_scrapy.extension import HubstorageMiddleware
+from sh_scrapy.extension import HubstorageExtension, HubstorageMiddleware
+from sh_scrapy.middlewares import HS_PARENT_ID_KEY
 
 
 @pytest.fixture
@@ -108,5 +109,5 @@ def test_hs_mware_process_spider_output_filter_request(hs_mware):
         response, [child_response, child_request], Spider('test')))
     assert len(result) == 2
     # make sure that we update hsparent meta only for requests
-    assert result[0].meta.get('_hsparent') is None
-    assert result[1].meta['_hsparent'] == 'riq'
+    assert result[0].meta.get(HS_PARENT_ID_KEY) is None
+    assert result[1].meta[HS_PARENT_ID_KEY] == 'riq'

--- a/tests/test_middlewares.py
+++ b/tests/test_middlewares.py
@@ -1,0 +1,114 @@
+# -*- coding: utf-8 -*-
+from weakref import WeakKeyDictionary
+
+import itertools
+import pytest
+from scrapy import Spider, Request, Item
+from scrapy.http import Response
+
+from sh_scrapy.middlewares import (
+    HubstorageSpiderMiddleware, HubstorageDownloaderMiddleware,
+    HS_REQUEST_ID_KEY, HS_PARENT_ID_KEY
+)
+
+
+@pytest.fixture()
+def monkeypatch_globals(monkeypatch):
+    monkeypatch.setattr('sh_scrapy.middlewares.request_id_sequence', itertools.count())
+    monkeypatch.setattr('sh_scrapy.middlewares.seen_requests', WeakKeyDictionary())
+
+
+@pytest.fixture()
+def hs_spider_middleware(monkeypatch_globals):
+    return HubstorageSpiderMiddleware()
+
+
+@pytest.fixture()
+def hs_downloader_middleware(monkeypatch_globals):
+    return HubstorageDownloaderMiddleware()
+
+
+def test_hs_middlewares(hs_downloader_middleware, hs_spider_middleware):
+    assert hs_spider_middleware._seen_requests == WeakKeyDictionary()
+    assert hs_downloader_middleware._seen_requests == WeakKeyDictionary()
+    assert hs_spider_middleware._seen_requests is hs_downloader_middleware._seen_requests
+
+    spider = Spider('test')
+    url = 'http://resp-url'
+    request_0 = Request(url)
+    response_0 = Response(url)
+
+    hs_downloader_middleware.process_request(request_0, spider)
+
+    assert HS_REQUEST_ID_KEY not in request_0.meta
+    assert HS_PARENT_ID_KEY not in request_0.meta
+    assert len(hs_spider_middleware._seen_requests) == 0
+    assert len(hs_downloader_middleware._seen_requests) == 0
+
+    hs_downloader_middleware.process_response(request_0, response_0, spider)
+
+    assert request_0.meta[HS_REQUEST_ID_KEY] == 0
+    assert request_0.meta[HS_PARENT_ID_KEY] is None
+    assert hs_spider_middleware._seen_requests[request_0] == 0
+
+    response_0.request = request_0
+    request_1 = Request(url)
+    request_2 = Request(url)
+    item1 = {}
+    item2 = Item()
+    output = [request_1, request_2, item1, item2]
+    processed_output = list(hs_spider_middleware.process_spider_output(response_0, output, spider))
+
+    assert processed_output[0] is request_1
+    assert request_1.meta[HS_PARENT_ID_KEY] == 0
+    assert processed_output[1] is request_2
+    assert request_2.meta[HS_PARENT_ID_KEY] == 0
+    assert processed_output[2] is item1
+    assert processed_output[3] is item2
+
+    response_1 = Response(url)
+    hs_downloader_middleware.process_request(request_1, spider)
+    hs_downloader_middleware.process_response(request_1, response_1, spider)
+    assert request_1.meta[HS_REQUEST_ID_KEY] == 1
+    assert request_1.meta[HS_PARENT_ID_KEY] == 0
+
+    response_2 = Response(url)
+    hs_downloader_middleware.process_request(request_2, spider)
+    hs_downloader_middleware.process_response(request_2, response_2, spider)
+    assert request_2.meta[HS_REQUEST_ID_KEY] == 2
+    assert request_2.meta[HS_PARENT_ID_KEY] == 0
+
+
+def test_hs_middlewares_retry(hs_downloader_middleware, hs_spider_middleware):
+    spider = Spider('test')
+    url = 'http://resp-url'
+    request_0 = Request(url)
+    response_0 = Response(url)
+
+    hs_downloader_middleware.process_request(request_0, spider)
+
+    assert HS_REQUEST_ID_KEY not in request_0.meta
+    assert HS_PARENT_ID_KEY not in request_0.meta
+    assert len(hs_spider_middleware._seen_requests) == 0
+    assert len(hs_downloader_middleware._seen_requests) == 0
+
+    hs_downloader_middleware.process_response(request_0, response_0, spider)
+
+    assert request_0.meta[HS_REQUEST_ID_KEY] == 0
+    assert request_0.meta[HS_PARENT_ID_KEY] is None
+    assert hs_spider_middleware._seen_requests[request_0] == 0
+
+    request_1 = request_0.copy()
+    response_1 = Response(url)
+    assert request_1.meta[HS_REQUEST_ID_KEY] == 0
+    assert request_1.meta[HS_PARENT_ID_KEY] is None
+
+    hs_downloader_middleware.process_request(request_1, spider)
+
+    assert HS_REQUEST_ID_KEY not in request_1.meta
+    assert request_1.meta[HS_PARENT_ID_KEY] == 0
+
+    hs_downloader_middleware.process_response(request_1, response_1, spider)
+
+    assert request_1.meta[HS_REQUEST_ID_KEY] == 1
+    assert request_1.meta[HS_PARENT_ID_KEY] == 0

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -356,8 +356,10 @@ def test_load_default_settings():
     assert extensions['scrapy.extensions.debug.StackTraceDump'] == 0
     assert extensions['sh_scrapy.extension.HubstorageExtension'] == 100
     assert 'slybot.closespider.SlybotCloseSpider' not in extensions
-    mwares = result['SPIDER_MIDDLEWARES_BASE']
-    assert 'sh_scrapy.extension.HubstorageMiddleware' in mwares
+    spider_middlewares = result['SPIDER_MIDDLEWARES_BASE']
+    assert 'sh_scrapy.middlewares.HubstorageSpiderMiddleware' in spider_middlewares
+    downloader_middlewares = result['DOWNLOADER_MIDDLEWARES_BASE']
+    assert 'sh_scrapy.middlewares.HubstorageDownloaderMiddleware' in downloader_middlewares
     assert result['MEMUSAGE_LIMIT_MB'] == 950
 
 


### PR DESCRIPTION
Deprecate HubstorageMiddleware.
Add HubstorageSpiderMiddleware and HubstorageDownloaderMiddleware that
store all performed requests.

Fixes #41