### PR TITLE
Use newer addons paths when possible

### DIFF
--- a/sh_scrapy/settings.py
+++ b/sh_scrapy/settings.py
@@ -16,6 +16,12 @@ REPLACE_ADDONS_PATHS = {
         "scrapy_dotpersistence.DotScrapyPersistence",
     "scrapylib.deltafetch.DeltaFetch":
         "scrapy_deltafetch.middleware.DeltaFetch",
+    "scrapylib.magicfields.MagicFieldsMiddleware":
+        "scrapy_magicfields.MagicFieldsMiddleware",
+    "scrapylib.querycleaner.QueryCleanerMiddleware":
+        "scrapy_querycleaner.QueryCleanerMiddleware",
+    "scrapylib.splitvariants.SplitVariantsMiddleware":
+        "scrapy_splitvariants.SplitVariantsMiddleware",
 }
 SLYBOT_SPIDER_MANAGER = 'slybot.spidermanager.ZipfileSlybotSpiderManager'
 SLYBOT_DUPE_FILTER = 'slybot.dupefilter.DupeFilterPipeline'


### PR DESCRIPTION
When one of the addons is enabled on Dash, we still use oldy and deprecated `scrapylib` by default, even if a new version of the package is installed - it's unobvious and leads to more complex manual setup. We could easilty fix it in the same way like we do for Deltafetch & DotScrapy addons - use new version if installed or fallback to default one if not.

Please take a quick look and let me know if I'm missing something.