### PR TITLE
Use scrapy.statscollectors inplace of deprecated scrapy.statscol

### DIFF
--- a/sh_scrapy/stats.py
+++ b/sh_scrapy/stats.py
@@ -1,5 +1,5 @@
 from twisted.internet import task
-from scrapy.statscol import StatsCollector
+from scrapy.statscollectors import StatsCollector
 
 from sh_scrapy import hsref
 from sh_scrapy.writer import pipe_writer


### PR DESCRIPTION
I am getting some annoying warnings due to this package using the deprecated scrapy module `scrapy.statscol` which is simply calling `scrapy.statscollectors`.

This is just replacing the old module with the new one.