### PR TITLE
Add test-crawl command to run locally

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -16,6 +16,7 @@ setup(
             'start-crawl = sh_scrapy.crawl:main',
             'list-spiders = sh_scrapy.crawl:list_spiders',
             'shub-image-info = sh_scrapy.crawl:shub_image_info',
+            'test-crawl = sh_scrapy.local:test_crawl',
         ],
     },
     classifiers=[

--- a/sh_scrapy/local.py
+++ b/sh_scrapy/local.py
@@ -1,0 +1,57 @@
+import os
+import logging
+import warnings
+
+from sh_scrapy.crawl import (
+    _fatalerror, ignore_warnings, _get_apisettings, _run,
+)
+from sh_scrapy.env import _job_args_and_env, _make_scrapy_args
+
+
+def get_args_and_env(msg):
+    # must: spider; optional: job_cmd, job_env, spider_args, settings
+    if 'job_cmd' in msg:
+        return _job_args_and_env(msg)
+    args = ['scrapy', 'crawl', str(msg['spider'])] + \
+        _make_scrapy_args('-a', msg.get('spider_args')) + \
+        _make_scrapy_args('-s', msg.get('settings'))
+    env = msg['job_env'] if isinstance(msg.get('job_env'), dict) else {}
+    return args, env
+
+
+def _run_usercode(spider, args, apisettings_func):
+    try:
+        from scrapy.exceptions import ScrapyDeprecationWarning
+        from sh_scrapy.settings import populate_base_settings
+
+        with ignore_warnings(category=ScrapyDeprecationWarning):
+            settings = populate_base_settings(apisettings_func(), spider)
+    except Exception:
+        logging.exception('Settings initialization failed')
+        raise
+    try:
+        _run(args, settings)
+    except Exception:
+        logging.exception('Job runtime exception')
+        raise
+
+
+def test_crawl():
+    try:
+        from scrapy.exceptions import ScrapyDeprecationWarning
+        warnings.filterwarnings(
+            'ignore', category=ScrapyDeprecationWarning, module='^sh_scrapy')
+        from sh_scrapy.env import decode_uri
+        job = decode_uri(envvar='SHUB_JOB_DATA')
+        assert job, 'SHUB_JOB_DATA must be set'
+
+        args, env = get_args_and_env(job)
+        os.environ.update(env)
+
+        from sh_scrapy.env import setup_environment
+        setup_environment()
+    except:
+        _fatalerror()
+        raise
+
+    _run_usercode(job['spider'], args, _get_apisettings)

--- a/sh_scrapy/settings.py
+++ b/sh_scrapy/settings.py
@@ -239,3 +239,8 @@ def _enforce_required_settings(settings):
 
 def populate_settings(apisettings, spider=None):
     return _populate_settings_base(apisettings, _load_default_settings, spider)
+
+
+def populate_base_settings(apisettings, spider=None):
+    """Populate settings ignoring default ones."""
+    return _populate_settings_base(apisettings, lambda settings: None, spider)


### PR DESCRIPTION
As a part of the work to allow running custom images locally, there's a proposal to add a new command to the current layer: similar to the `start-crawl` logic but significantly simplified:
- requiring only the minimal set of environment vars to start
- with default stdout/stderr output
- without default settings required for Scrapy Cloud

The library is very well-designed, so it's straightforward to reuse the existing helpers, and I want to keep it well-designed, so my main concerns here are mostly about naming (module `local`, command `test-crawl`). Maybe there's anything else you would add to the changes.

Related changes in shub tool (I'll create a PR when we agree on the design)
https://github.com/scrapinghub/shub/compare/run-custom-image-locally?expand=1

Please, take a look and let me know your thoughts.