### PR TITLE
Add support for dataclass and attrs

### DIFF
--- a/sh_scrapy/extension.py
+++ b/sh_scrapy/extension.py
@@ -17,6 +17,13 @@ from sh_scrapy.middlewares import HS_PARENT_ID_KEY, request_id_sequence
 from sh_scrapy.writer import pipe_writer
 
 
+try:
+    from itemadapter import is_item
+except ImportError:
+    def is_item(item):
+        return isinstance(item, (dict, BaseItem))
+
+
 class HubstorageExtension(object):
     """Extension to write scraped items to HubStorage"""
 
@@ -39,7 +46,7 @@ class HubstorageExtension(object):
         return o
 
     def item_scraped(self, item, spider):
-        if not isinstance(item, (dict, BaseItem)):
+        if not is_item(item):
             self.logger.error("Wrong item type: %s" % item)
             return
         type_ = type(item).__name__

--- a/tests/test_extension.py
+++ b/tests/test_extension.py
@@ -57,6 +57,7 @@ def test_hs_ext_dataclass_item_scraped(hs_ext):
 def test_hs_ext_attrs_item_scraped(hs_ext):
     try:
         import attr
+        import iteamadapter
     except ImportError:
         pytest.skip('attrs not installed')
         return

--- a/tests/test_extension.py
+++ b/tests/test_extension.py
@@ -38,6 +38,41 @@ def test_hs_ext_binary_exporter_py3(hs_ext):
     assert not getattr(hs_ext.exporter, 'binary')
 
 
+@pytest.mark.skipif(sys.version_info < (3, 7), reason="requires python3.7")
+def test_hs_ext_dataclass_item_scraped(hs_ext):
+    from dataclasses import dataclass
+
+    @dataclass
+    class DataclassItem:
+        pass
+
+    hs_ext._write_item = mock.Mock()
+    item = DataclassItem()
+    spider = Spider('test')
+    hs_ext.item_scraped(item, spider)
+    assert hs_ext._write_item.call_count == 1
+    assert hs_ext._write_item.call_args[0] == ({'_type': 'DataclassItem'},)
+
+
+def test_hs_ext_attrs_item_scraped(hs_ext):
+    try:
+        import attr
+    except ImportError:
+        pytest.skip('attrs not installed')
+        return
+
+    @attr.s
+    class AttrsItem:
+        pass
+
+    hs_ext._write_item = mock.Mock()
+    item = AttrsItem()
+    spider = Spider('test')
+    hs_ext.item_scraped(item, spider)
+    assert hs_ext._write_item.call_count == 1
+    assert hs_ext._write_item.call_args[0] == ({'_type': 'AttrsItem'},)
+
+
 def test_hs_ext_item_scraped(hs_ext):
     hs_ext._write_item = mock.Mock()
     item = Item()

--- a/tests/test_extension.py
+++ b/tests/test_extension.py
@@ -62,7 +62,7 @@ def test_hs_ext_attrs_item_scraped(hs_ext):
         return
 
     @attr.s
-    class AttrsItem:
+    class AttrsItem(object):
         pass
 
     hs_ext._write_item = mock.Mock()


### PR DESCRIPTION
Since version 2.2 scrapy supports `attrs` and `dataclass` as items. https://docs.scrapy.org/en/latest/news.html#scrapy-2-2-0-2020-06-24
Though, when yielding these item types in Scrapy Cloud we get a not supported item type error.
This PR should fix this issue