### PR TITLE
Extend test matrix, release with py36

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,12 @@ matrix:
       env: TOXENV=py35
     - python: 3.6
       env: TOXENV=py36
+    - python: 3.7
+      env: TOXENV=py37
+    - python: 3.8
+      env: TOXENV=py38
+    - python: 3.9
+      env: TOXENV=py39
 install:
   - pip install tox
   - pip install -U tox coverage codecov pytest-xdist
@@ -30,6 +36,6 @@ deploy:
   user: scrapinghub
   on:
     tags: true
-    condition: $TOXENV == py27 && $TRAVIS_TAG =~ ^v[0-9]+[.][0-9]+[.][0-9]+(rc[0-9]+|[.]dev[0-9]+)?$
+    condition: $TOXENV == py36 && $TRAVIS_TAG =~ ^v[0-9]+[.][0-9]+[.][0-9]+(rc[0-9]+|[.]dev[0-9]+)?$
   password:
     secure: 05NUQdIRHlT+9T85SJXWfg35q3bk7vlpkfHfwisDkbcJnD5+kymRTzbSzhABQxh3bpc0QHRc2bF1PfgCjumaJMarp3K0unsOdptleUwhorizkyvnD8xzxWd+8GFUDBzoCLJqC9TQK05wWrTqbGbZ+stPnatEx7SfJEHbxhKeL7M=


### PR DESCRIPTION
Let's ensure it works fine with newer Python versions + release with Python 3.6 (latest pip used for deploy fails because of f-string).