### PR TITLE
Update dependencies, drop py35, test in py310, improve itemadapter performance

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -10,24 +10,24 @@ jobs:
       fail-fast: false
       matrix:
         include:
-        - python-version: "3.5"
-          env:
-            TOXENV: py35-scrapy18
-        - python-version: "3.5"
-          env:
-            TOXENV: py35
         - python-version: "3.6"
           env:
-            TOXENV: py36
+            TOXENV: py36-scrapy16
+        - python-version: "3.6"
+          env:
+            TOXENV: py
         - python-version: "3.7"
           env:
-            TOXENV: py37
+            TOXENV: py
         - python-version: "3.8"
           env:
-            TOXENV: py38
+            TOXENV: py
         - python-version: "3.9"
           env:
-            TOXENV: py39
+            TOXENV: py
+        - python-version: "3.10"
+          env:
+            TOXENV: py
 
     steps:
     - uses: actions/checkout@v2

--- a/setup.py
+++ b/setup.py
@@ -8,8 +8,8 @@ setup(
     long_description=open('README.md').read(),
     packages=find_packages(),
     install_requires=[
-        'Scrapy>=1.0',
-        'scrapinghub>=1.9.0',
+        'Scrapy>=1.6',
+        'scrapinghub>=2.1.0',
     ],
     entry_points={
         'console_scripts': [
@@ -18,7 +18,7 @@ setup(
             'shub-image-info = sh_scrapy.crawl:shub_image_info',
         ],
     },
-    python_requires='>=3.5',
+    python_requires='>=3.6',
     classifiers=[
         'Framework :: Scrapy',
         'Development Status :: 5 - Production/Stable',
@@ -27,11 +27,11 @@ setup(
         'Operating System :: OS Independent',
         'Programming Language :: Python',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',
+        'Programming Language :: Python :: 3.10',
         'Topic :: Utilities',
     ],
 )

--- a/sh_scrapy/extension.py
+++ b/sh_scrapy/extension.py
@@ -24,9 +24,10 @@ except ImportError:
     _base_item_cls = [dict, scrapy.item.Item]
     with suppress(AttributeError):
         _base_item_cls.append(scrapy.item.BaseItem)
+    _base_item_cls = tuple(_base_item_cls)
 
     def is_item(item):
-        return isinstance(item, tuple(_base_item_cls))
+        return isinstance(item, _base_item_cls)
 else:
     def is_item(item):
         return ItemAdapter.is_item(item)

--- a/sh_scrapy/extension.py
+++ b/sh_scrapy/extension.py
@@ -19,7 +19,7 @@ from sh_scrapy.writer import pipe_writer
 
 
 try:
-    from itemadapter import is_item
+    from itemadapter import ItemAdapter
 except ImportError:
     _base_item_cls = [dict, scrapy.item.Item]
     with suppress(AttributeError):
@@ -27,6 +27,9 @@ except ImportError:
 
     def is_item(item):
         return isinstance(item, tuple(_base_item_cls))
+else:
+    def is_item(item):
+        return ItemAdapter.is_item(item)
 
 
 class HubstorageExtension(object):

--- a/tests/test_writer.py
+++ b/tests/test_writer.py
@@ -3,8 +3,8 @@ import json
 import logging
 import os
 import threading
+from queue import Queue
 
-from six.moves.queue import Queue
 import pytest
 
 from sh_scrapy.writer import _PipeWriter

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 # tox.ini
 [tox]
-envlist = py35-scrapy18, py35, py36, py37, py38, py39
+envlist = py36-scrapy16, py
 
 [testenv]
 deps =
@@ -10,6 +10,6 @@ deps =
     hubstorage
     six
     packaging
-    py35-scrapy18: Scrapy==1.8
+    py36-scrapy16: Scrapy==1.6
 commands =
     pytest --verbose --cov=sh_scrapy --cov-report=term-missing --cov-report=html --cov-report=xml {posargs: sh_scrapy tests}

--- a/tox.ini
+++ b/tox.ini
@@ -8,7 +8,6 @@ deps =
     pytest-cov
     mock
     hubstorage
-    six
     packaging
     py36-scrapy16: Scrapy==1.6
 commands =


### PR DESCRIPTION
* Drop Python 3.5 support
* Add Python 3.10 support
* Bump minimum dependencies: [Scrapy 1.6](https://docs.scrapy.org/en/latest/news.html#scrapy-1-6-0-2019-01-30) (2019-01-30), [python-scrapinghub 2.1.0](https://github.com/scrapinghub/python-scrapinghub/releases/tag/2.1.0) (2019-01-14)
* Improve performance by updating `itemadapter` usage
* Remove `six` as test dependency

---


Calling `itemadapter.ItemAdapter.is_item` directly instead of the `itemadapter.is_item` alias (which imports `itemadapter.ItemAdapter` on each call) is faster:
```python
from timeit import timeit
from itemadapter import is_item, ItemAdapter
from scrapy.item import Item

def test_dict_alias():
    return is_item({})

def test_dict_direct():
    return ItemAdapter.is_item({})

def test_item_alias():
    return is_item(Item())

def test_item_direct():
    return ItemAdapter.is_item(Item())

print("test_dict_alias: ", timeit(test_dict_alias, number=10**6))
print("test_dict_direct:", timeit(test_dict_direct, number=10**6))
print("test_item_alias: ", timeit(test_item_alias, number=10**6))
print("test_item_direct:", timeit(test_item_direct, number=10**6))
```

```
test_dict_alias:  2.2290923200000003
test_dict_direct: 1.314303395
test_item_alias:  3.5215694760000003
test_item_direct: 2.772791269
```

(At https://github.com/scrapy/itemadapter/commit/1203b5e54ad75c50279f8bbee05837a6f0c1d63c, with a 2020 Macbook Pro, Intel(R) Core(TM) i5-1038NG7 CPU @ 2.00GHz)

See also https://github.com/scrapy/itemadapter/issues/59 and the issues/PRs linked there.