### PR TITLE
Deprecate sh_scrapy.compat module

### DIFF
--- a/sh_scrapy/compat.py
+++ b/sh_scrapy/compat.py
@@ -1,70 +1,32 @@
 import warnings
 
 from scrapy.exceptions import ScrapyDeprecationWarning
-
-
-def to_str(text, encoding=None, errors='strict'):
-    """Return the unicode representation of `text`.
-
-    If `text` is already a ``str`` object, return it as-is.
-    If `text` is a ``bytes`` object, decode it using `encoding`.
-
-    Otherwise, raise an error.
-    """
-    if isinstance(text, str):
-        return text
-    if not isinstance(text, bytes):
-        raise TypeError('to_str must receive a bytes or str '
-                        'object, got %s' % type(text).__name__)
-    if encoding is None:
-        encoding = 'utf-8'
-    return text.decode(encoding, errors)
-
-
-def to_bytes(text, encoding=None, errors='strict'):
-    """Return the binary representation of `text`.
-
-    If `text` is already a ``bytes`` object, return it as-is.
-    If `text` is a ``unicode`` object, encode it using `encoding`.
-
-    Otherwise, raise an error.
-    """
-    if isinstance(text, bytes):
-        return text
-    if not isinstance(text, str):
-        raise TypeError('to_bytes must receive a str or bytes '
-                        'object, got %s' % type(text).__name__)
-    if encoding is None:
-        encoding = 'utf-8'
-    return text.encode(encoding, errors)
+from scrapy.utils.decorators import deprecated
+from scrapy.utils.python import (
+    to_bytes as scrapy_to_bytes,
+    to_unicode as scrapy_to_unicode,
+)
 
 
 def is_string(var):
     warnings.warn(
-        f"{_qualname(is_string)} is deprecated, please use isinstance(<var>, str) instead",
+        "is_string(var) is deprecated, please use isinstance(var, str) instead",
         category=ScrapyDeprecationWarning,
         stacklevel=2,
     )
     return isinstance(var, str)
 
 
+@deprecated("scrapy.utils.python.to_bytes")
+def to_bytes(text, encoding=None, errors='strict'):
+    return scrapy_to_bytes(text, encoding, errors)
+
+
+@deprecated("scrapy.utils.python.to_unicode")
 def to_native_str(text, encoding=None, errors='strict'):
-    warnings.warn(
-        f"{_qualname(to_native_str)} is deprecated, please use {_qualname(to_str)} instead",
-        category=ScrapyDeprecationWarning,
-        stacklevel=2,
-    )
-    return to_str(text, encoding, errors)
+    return scrapy_to_unicode(text, encoding, errors)
 
 
+@deprecated("scrapy.utils.python.to_unicode")
 def to_unicode(text, encoding=None, errors='strict'):
-    warnings.warn(
-        f"{_qualname(to_unicode)} is deprecated, please use {_qualname(to_str)} instead",
-        category=ScrapyDeprecationWarning,
-        stacklevel=2,
-    )
-    return to_str(text, encoding, errors)
-
-
-def _qualname(obj) -> str:
-    return f"{obj.__module__}.{obj.__qualname__}"
+    return scrapy_to_unicode(text, encoding, errors)

--- a/sh_scrapy/compat.py
+++ b/sh_scrapy/compat.py
@@ -32,11 +32,20 @@ def to_bytes(text, encoding=None, errors='strict'):
     if isinstance(text, bytes):
         return text
     if not isinstance(text, str):
-        raise TypeError('to_bytes must receive a unicode, str or bytes '
+        raise TypeError('to_bytes must receive a str or bytes '
                         'object, got %s' % type(text).__name__)
     if encoding is None:
         encoding = 'utf-8'
     return text.encode(encoding, errors)
+
+
+def is_string(var):
+    warnings.warn(
+        f"{_qualname(is_string)} is deprecated, please use isinstance(<var>, str) instead",
+        category=ScrapyDeprecationWarning,
+        stacklevel=2,
+    )
+    return isinstance(var, str)
 
 
 def to_native_str(text, encoding=None, errors='strict'):

--- a/sh_scrapy/compat.py
+++ b/sh_scrapy/compat.py
@@ -1,3 +1,4 @@
+import sys
 import warnings
 
 from scrapy.exceptions import ScrapyDeprecationWarning
@@ -5,6 +6,19 @@ from scrapy.utils.decorators import deprecated
 from scrapy.utils.python import (
     to_bytes as scrapy_to_bytes,
     to_unicode as scrapy_to_unicode,
+)
+
+
+IS_PYTHON2 = sys.version_info < (3,)
+STRING_TYPE = str
+TEXT_TYPE = str
+BINARY_TYPE = bytes
+
+
+warnings.warn(
+    "The sh_scrapy.compat module is deprecated, use the functions in scrapy.utils.python instead",
+    category=ScrapyDeprecationWarning,
+    stacklevel=2,
 )
 
 

--- a/sh_scrapy/compat.py
+++ b/sh_scrapy/compat.py
@@ -1,4 +1,3 @@
-import sys
 import warnings
 
 from scrapy.exceptions import ScrapyDeprecationWarning
@@ -9,7 +8,7 @@ from scrapy.utils.python import (
 )
 
 
-IS_PYTHON2 = sys.version_info < (3,)
+IS_PYTHON2 = False
 STRING_TYPE = str
 TEXT_TYPE = str
 BINARY_TYPE = bytes

--- a/sh_scrapy/compat.py
+++ b/sh_scrapy/compat.py
@@ -1,21 +1,20 @@
-STRING_TYPE = str
-TEXT_TYPE = str
-BINARY_TYPE = bytes
+import warnings
+
+from scrapy.exceptions import ScrapyDeprecationWarning
 
 
-def to_unicode(text, encoding=None, errors='strict'):
+def to_str(text, encoding=None, errors='strict'):
     """Return the unicode representation of `text`.
 
-    If `text` is already a ``unicode`` object, return it as-is.
+    If `text` is already a ``str`` object, return it as-is.
     If `text` is a ``bytes`` object, decode it using `encoding`.
 
     Otherwise, raise an error.
-
     """
-    if isinstance(text, TEXT_TYPE):
+    if isinstance(text, str):
         return text
-    if not isinstance(text, BINARY_TYPE):
-        raise TypeError('to_unicode must receive a bytes, str or unicode '
+    if not isinstance(text, bytes):
+        raise TypeError('to_str must receive a bytes or str '
                         'object, got %s' % type(text).__name__)
     if encoding is None:
         encoding = 'utf-8'
@@ -28,10 +27,11 @@ def to_bytes(text, encoding=None, errors='strict'):
     If `text` is already a ``bytes`` object, return it as-is.
     If `text` is a ``unicode`` object, encode it using `encoding`.
 
-    Otherwise, raise an error."""
-    if isinstance(text, BINARY_TYPE):
+    Otherwise, raise an error.
+    """
+    if isinstance(text, bytes):
         return text
-    if not isinstance(text, TEXT_TYPE):
+    if not isinstance(text, str):
         raise TypeError('to_bytes must receive a unicode, str or bytes '
                         'object, got %s' % type(text).__name__)
     if encoding is None:
@@ -40,8 +40,22 @@ def to_bytes(text, encoding=None, errors='strict'):
 
 
 def to_native_str(text, encoding=None, errors='strict'):
-    """Return ``str`` representation of `text`.
+    warnings.warn(
+        f"{_qualname(to_native_str)} is deprecated, please use {_qualname(to_str)} instead",
+        category=ScrapyDeprecationWarning,
+        stacklevel=2,
+    )
+    return to_str(text, encoding, errors)
 
-    ``str`` representation means ``bytes`` in PY2 and ``unicode`` in PY3.
-    """
-    return to_unicode(text, encoding, errors)
+
+def to_unicode(text, encoding=None, errors='strict'):
+    warnings.warn(
+        f"{_qualname(to_unicode)} is deprecated, please use {_qualname(to_str)} instead",
+        category=ScrapyDeprecationWarning,
+        stacklevel=2,
+    )
+    return to_str(text, encoding, errors)
+
+
+def _qualname(obj) -> str:
+    return f"{obj.__module__}.{obj.__qualname__}"

--- a/sh_scrapy/compat.py
+++ b/sh_scrapy/compat.py
@@ -3,10 +3,6 @@ TEXT_TYPE = str
 BINARY_TYPE = bytes
 
 
-def is_string(var):
-    return isinstance(var, STRING_TYPE)
-
-
 def to_unicode(text, encoding=None, errors='strict'):
     """Return the unicode representation of `text`.
 

--- a/sh_scrapy/compat.py
+++ b/sh_scrapy/compat.py
@@ -1,15 +1,6 @@
-import sys
-
-
-IS_PYTHON2 = sys.version_info < (3,)
-if IS_PYTHON2:
-    STRING_TYPE = basestring
-    TEXT_TYPE = unicode
-    BINARY_TYPE = str
-else:
-    STRING_TYPE = str
-    TEXT_TYPE = str
-    BINARY_TYPE = bytes
+STRING_TYPE = str
+TEXT_TYPE = str
+BINARY_TYPE = bytes
 
 
 def is_string(var):
@@ -57,6 +48,4 @@ def to_native_str(text, encoding=None, errors='strict'):
 
     ``str`` representation means ``bytes`` in PY2 and ``unicode`` in PY3.
     """
-    if IS_PYTHON2:
-        return to_bytes(text, encoding, errors)
     return to_unicode(text, encoding, errors)

--- a/sh_scrapy/env.py
+++ b/sh_scrapy/env.py
@@ -2,7 +2,7 @@ import os
 import json
 import codecs
 from base64 import b64decode
-from sh_scrapy.compat import to_bytes, to_native_str
+from sh_scrapy.compat import to_bytes, to_str
 
 
 def _make_scrapy_args(arg, args_dict):
@@ -11,7 +11,7 @@ def _make_scrapy_args(arg, args_dict):
     args = []
     for k, v in sorted(dict(args_dict).items()):
         args += [arg, "{}={}".format(
-            to_native_str(k), to_native_str(v) if isinstance(v, str) else v)]
+            to_str(k), to_str(v) if isinstance(v, str) else v)]
     return args
 
 
@@ -36,7 +36,7 @@ def _job_args_and_env(msg):
     cmd = msg.get('job_cmd')
     if not isinstance(cmd, list):
         cmd = [str(cmd)]
-    return cmd, {to_native_str(k): to_native_str(v) if isinstance(v, str) else v
+    return cmd, {to_str(k): to_str(v) if isinstance(v, str) else v
                  for k, v in sorted(dict(env).items())}
 
 
@@ -51,7 +51,7 @@ def _jobname(msg):
 
 def _jobauth(msg):
     auth_data = to_bytes('{0[key]}:{0[auth]}'.format(msg))
-    return to_native_str(codecs.encode(auth_data, 'hex_codec'))
+    return to_str(codecs.encode(auth_data, 'hex_codec'))
 
 
 def get_args_and_env(msg):

--- a/sh_scrapy/env.py
+++ b/sh_scrapy/env.py
@@ -2,7 +2,7 @@ import os
 import json
 import codecs
 from base64 import b64decode
-from sh_scrapy.compat import to_bytes, to_native_str, is_string
+from sh_scrapy.compat import to_bytes, to_native_str
 
 
 def _make_scrapy_args(arg, args_dict):
@@ -11,7 +11,7 @@ def _make_scrapy_args(arg, args_dict):
     args = []
     for k, v in sorted(dict(args_dict).items()):
         args += [arg, "{}={}".format(
-            to_native_str(k), to_native_str(v) if is_string(v) else v)]
+            to_native_str(k), to_native_str(v) if isinstance(v, str) else v)]
     return args
 
 
@@ -36,7 +36,7 @@ def _job_args_and_env(msg):
     cmd = msg.get('job_cmd')
     if not isinstance(cmd, list):
         cmd = [str(cmd)]
-    return cmd, {to_native_str(k): to_native_str(v) if is_string(v) else v
+    return cmd, {to_native_str(k): to_native_str(v) if isinstance(v, str) else v
                  for k, v in sorted(dict(env).items())}
 
 

--- a/sh_scrapy/env.py
+++ b/sh_scrapy/env.py
@@ -2,7 +2,8 @@ import os
 import json
 import codecs
 from base64 import b64decode
-from sh_scrapy.compat import to_bytes, to_str
+
+from scrapy.utils.python import to_bytes, to_unicode
 
 
 def _make_scrapy_args(arg, args_dict):
@@ -11,7 +12,7 @@ def _make_scrapy_args(arg, args_dict):
     args = []
     for k, v in sorted(dict(args_dict).items()):
         args += [arg, "{}={}".format(
-            to_str(k), to_str(v) if isinstance(v, str) else v)]
+            to_unicode(k), to_unicode(v) if isinstance(v, str) else v)]
     return args
 
 
@@ -36,7 +37,7 @@ def _job_args_and_env(msg):
     cmd = msg.get('job_cmd')
     if not isinstance(cmd, list):
         cmd = [str(cmd)]
-    return cmd, {to_str(k): to_str(v) if isinstance(v, str) else v
+    return cmd, {to_unicode(k): to_unicode(v) if isinstance(v, str) else v
                  for k, v in sorted(dict(env).items())}
 
 
@@ -51,7 +52,7 @@ def _jobname(msg):
 
 def _jobauth(msg):
     auth_data = to_bytes('{0[key]}:{0[auth]}'.format(msg))
-    return to_str(codecs.encode(auth_data, 'hex_codec'))
+    return to_unicode(codecs.encode(auth_data, 'hex_codec'))
 
 
 def get_args_and_env(msg):

--- a/sh_scrapy/extension.py
+++ b/sh_scrapy/extension.py
@@ -11,7 +11,6 @@ from scrapy.utils.deprecate import create_deprecated_class
 from scrapy.utils.request import request_fingerprint
 
 from sh_scrapy import hsref
-from sh_scrapy.compat import IS_PYTHON2
 from sh_scrapy.crawl import ignore_warnings
 from sh_scrapy.exceptions import SHScrapyDeprecationWarning
 from sh_scrapy.middlewares import HS_PARENT_ID_KEY, request_id_sequence
@@ -39,7 +38,7 @@ class HubstorageExtension(object):
         self.logger = logging.getLogger(__name__)
         self._write_item = self.pipe_writer.write_item
         # https://github.com/scrapy/scrapy/commit/c76190d491fca9f35b6758bdc06c34d77f5d9be9
-        exporter_kwargs = {'binary': False} if not IS_PYTHON2 else {}
+        exporter_kwargs = {'binary': False}
         with ignore_warnings(category=ScrapyDeprecationWarning):
             self.exporter = PythonItemExporter(**exporter_kwargs)
 

--- a/sh_scrapy/hsref.py
+++ b/sh_scrapy/hsref.py
@@ -3,7 +3,7 @@ Module to hold a reference to singleton Hubstorage client and Job instance
 """
 import os
 from codecs import decode
-from sh_scrapy.compat import to_native_str
+from sh_scrapy.compat import to_str
 
 
 class _HubstorageRef(object):
@@ -24,7 +24,7 @@ class _HubstorageRef(object):
 
     @property
     def auth(self):
-        return to_native_str(decode(os.environ['SHUB_JOBAUTH'], 'hex_codec'))
+        return to_str(decode(os.environ['SHUB_JOBAUTH'], 'hex_codec'))
 
     @property
     def endpoint(self):

--- a/sh_scrapy/hsref.py
+++ b/sh_scrapy/hsref.py
@@ -3,7 +3,8 @@ Module to hold a reference to singleton Hubstorage client and Job instance
 """
 import os
 from codecs import decode
-from sh_scrapy.compat import to_str
+
+from scrapy.utils.python import to_unicode
 
 
 class _HubstorageRef(object):
@@ -24,7 +25,7 @@ class _HubstorageRef(object):
 
     @property
     def auth(self):
-        return to_str(decode(os.environ['SHUB_JOBAUTH'], 'hex_codec'))
+        return to_unicode(decode(os.environ['SHUB_JOBAUTH'], 'hex_codec'))
 
     @property
     def endpoint(self):

--- a/sh_scrapy/log.py
+++ b/sh_scrapy/log.py
@@ -2,10 +2,10 @@ import logging
 import sys
 import warnings
 
-from twisted.python import log as txlog
 from scrapy import __version__
+from twisted.python import log as txlog
+from scrapy.utils.python import to_unicode
 
-from sh_scrapy.compat import to_str
 from sh_scrapy.writer import pipe_writer
 
 
@@ -120,7 +120,7 @@ class HubstorageLogObserver(object):
 
         msg = ev.get('message')
         if msg:
-            msg = to_str(msg[0])
+            msg = to_unicode(msg[0])
 
         failure = ev.get('failure', None)
         if failure:
@@ -156,7 +156,7 @@ class StdoutLogger(txlog.StdioOnnaStick):
         _logfn(message=self.prefix + msg, level=self.loglevel)
 
     def write(self, data):
-        data = to_str(data, self.encoding)
+        data = to_unicode(data, self.encoding)
 
         d = (self.buf + data).split('\n')
         self.buf = d[-1]
@@ -166,5 +166,5 @@ class StdoutLogger(txlog.StdioOnnaStick):
 
     def writelines(self, lines):
         for line in lines:
-            line = to_str(line, self.encoding)
+            line = to_unicode(line, self.encoding)
             self._logprefixed(line)

--- a/sh_scrapy/log.py
+++ b/sh_scrapy/log.py
@@ -3,8 +3,8 @@ import sys
 import warnings
 
 from scrapy import __version__
-from twisted.python import log as txlog
 from scrapy.utils.python import to_unicode
+from twisted.python import log as txlog
 
 from sh_scrapy.writer import pipe_writer
 

--- a/sh_scrapy/log.py
+++ b/sh_scrapy/log.py
@@ -5,7 +5,7 @@ import warnings
 from twisted.python import log as txlog
 from scrapy import __version__
 
-from sh_scrapy.compat import to_native_str
+from sh_scrapy.compat import to_str
 from sh_scrapy.writer import pipe_writer
 
 
@@ -120,7 +120,7 @@ class HubstorageLogObserver(object):
 
         msg = ev.get('message')
         if msg:
-            msg = to_native_str(msg[0])
+            msg = to_str(msg[0])
 
         failure = ev.get('failure', None)
         if failure:
@@ -156,7 +156,7 @@ class StdoutLogger(txlog.StdioOnnaStick):
         _logfn(message=self.prefix + msg, level=self.loglevel)
 
     def write(self, data):
-        data = to_native_str(data, self.encoding)
+        data = to_str(data, self.encoding)
 
         d = (self.buf + data).split('\n')
         self.buf = d[-1]
@@ -166,5 +166,5 @@ class StdoutLogger(txlog.StdioOnnaStick):
 
     def writelines(self, lines):
         for line in lines:
-            line = to_native_str(line, self.encoding)
+            line = to_str(line, self.encoding)
             self._logprefixed(line)

--- a/sh_scrapy/settings.py
+++ b/sh_scrapy/settings.py
@@ -55,7 +55,7 @@ class EntrypointSettings(Settings):
     def set(self, name, value, priority='project'):
         super(EntrypointSettings, self).set(
             to_str(name),
-            to_str(value) if isinstance(value, str) else value,
+            value if isinstance(value, str) else value,
             priority=priority)
 
     def copy_to_dict(self):

--- a/sh_scrapy/settings.py
+++ b/sh_scrapy/settings.py
@@ -2,7 +2,7 @@ import os
 import sys
 import logging
 import tempfile
-from sh_scrapy.compat import to_native_str, is_string
+from sh_scrapy.compat import to_native_str
 from scrapy.settings import Settings
 from scrapy.utils.misc import load_object
 from scrapy.utils.project import get_project_settings
@@ -55,7 +55,7 @@ class EntrypointSettings(Settings):
     def set(self, name, value, priority='project'):
         super(EntrypointSettings, self).set(
             to_native_str(name),
-            to_native_str(value) if is_string(value) else value,
+            to_native_str(value) if isinstance(value, str) else value,
             priority=priority)
 
     def copy_to_dict(self):
@@ -110,7 +110,7 @@ def _update_old_classpaths(settings):
         elif not isinstance(setting_value, dict):
             continue
         for path in setting_value.keys():
-            if not is_string(path):
+            if not isinstance(path, str):
                 continue
             updated_path = update_classpath(path)
             if updated_path != path:

--- a/sh_scrapy/settings.py
+++ b/sh_scrapy/settings.py
@@ -2,7 +2,7 @@ import os
 import sys
 import logging
 import tempfile
-from sh_scrapy.compat import to_native_str
+from sh_scrapy.compat import to_str
 from scrapy.settings import Settings
 from scrapy.utils.misc import load_object
 from scrapy.utils.project import get_project_settings
@@ -54,8 +54,8 @@ class EntrypointSettings(Settings):
 
     def set(self, name, value, priority='project'):
         super(EntrypointSettings, self).set(
-            to_native_str(name),
-            to_native_str(value) if isinstance(value, str) else value,
+            to_str(name),
+            to_str(value) if isinstance(value, str) else value,
             priority=priority)
 
     def copy_to_dict(self):

--- a/sh_scrapy/settings.py
+++ b/sh_scrapy/settings.py
@@ -2,10 +2,11 @@ import os
 import sys
 import logging
 import tempfile
-from sh_scrapy.compat import to_str
+
 from scrapy.settings import Settings
 from scrapy.utils.misc import load_object
 from scrapy.utils.project import get_project_settings
+from scrapy.utils.python import to_unicode
 
 
 logger = logging.getLogger(__name__)
@@ -54,7 +55,7 @@ class EntrypointSettings(Settings):
 
     def set(self, name, value, priority='project'):
         super(EntrypointSettings, self).set(
-            to_str(name),
+            to_unicode(name),
             value if isinstance(value, str) else value,
             priority=priority)
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,15 +5,16 @@ import shutil
 import tempfile
 
 import pytest
+from scrapy.utils.python import to_unicode, to_bytes
 
 TEMP_DIR = tempfile.mkdtemp()
 SHUB_FIFO_PATH = os.path.join(TEMP_DIR, 'scrapinghub')
 os.environ['SHUB_FIFO_PATH'] = SHUB_FIFO_PATH
 
-from sh_scrapy.writer import pipe_writer
-from sh_scrapy.compat import to_str, to_bytes
+from sh_scrapy.writer import pipe_writer  # should go after setting SHUB_FIFO_PATH
 
-TEST_AUTH = to_str(codecs.encode(to_bytes('1/2/3:authstr'), 'hex_codec'))
+
+TEST_AUTH = to_unicode(codecs.encode(to_bytes('1/2/3:authstr'), 'hex_codec'))
 
 
 @pytest.fixture(scope='session', autouse=True)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -11,9 +11,9 @@ SHUB_FIFO_PATH = os.path.join(TEMP_DIR, 'scrapinghub')
 os.environ['SHUB_FIFO_PATH'] = SHUB_FIFO_PATH
 
 from sh_scrapy.writer import pipe_writer
-from sh_scrapy.compat import to_native_str, to_bytes
+from sh_scrapy.compat import to_str, to_bytes
 
-TEST_AUTH = to_native_str(codecs.encode(to_bytes('1/2/3:authstr'), 'hex_codec'))
+TEST_AUTH = to_str(codecs.encode(to_bytes('1/2/3:authstr'), 'hex_codec'))
 
 
 @pytest.fixture(scope='session', autouse=True)

--- a/tests/test_compat.py
+++ b/tests/test_compat.py
@@ -1,29 +1,29 @@
 import pytest
 
-from sh_scrapy.compat import to_bytes, to_str
+from scrapy.utils.python import to_bytes, to_unicode
 
 
-# Testing to_str conversion
+# Testing to_unicode conversion
 
 def test_to_str_an_utf8_encoded_string_to_str():
-    assert to_str(b'lel\xc3\xb1e') == u'lel\xf1e'
+    assert to_unicode(b'lel\xc3\xb1e') == u'lel\xf1e'
 
 
 def test_to_str_a_latin_1_encoded_string_to_str():
-    assert to_str(b'lel\xf1e', 'latin-1') == u'lel\xf1e'
+    assert to_unicode(b'lel\xf1e', 'latin-1') == u'lel\xf1e'
 
 
 def test_to_str_a_unicode_to_str_should_return_the_same_object():
-    assert to_str(u'\xf1e\xf1e\xf1e') == u'\xf1e\xf1e\xf1e'
+    assert to_unicode(u'\xf1e\xf1e\xf1e') == u'\xf1e\xf1e\xf1e'
 
 
 def test_to_str_a_strange_object_should_raise_TypeError():
     with pytest.raises(TypeError) as excinfo:
-        to_str(123)
+        to_unicode(123)
 
 
 def test_to_str_errors_argument():
-    assert to_str(b'a\xedb', 'utf-8', errors='replace') == u'a\ufffdb'
+    assert to_unicode(b'a\xedb', 'utf-8', errors='replace') == u'a\ufffdb'
 
 
 # Testing to_bytes conversion

--- a/tests/test_compat.py
+++ b/tests/test_compat.py
@@ -1,32 +1,32 @@
 import pytest
-from sh_scrapy.compat import to_bytes
-from sh_scrapy.compat import to_unicode
 
-# Testing to_unicode conversion
+from sh_scrapy.compat import to_bytes, to_str
 
 
-def test_to_unicode_an_utf8_encoded_string_to_unicode():
-    assert to_unicode(b'lel\xc3\xb1e') == u'lel\xf1e'
+# Testing to_str conversion
+
+def test_to_str_an_utf8_encoded_string_to_str():
+    assert to_str(b'lel\xc3\xb1e') == u'lel\xf1e'
 
 
-def test_to_unicode_a_latin_1_encoded_string_to_unicode():
-    assert to_unicode(b'lel\xf1e', 'latin-1') == u'lel\xf1e'
+def test_to_str_a_latin_1_encoded_string_to_str():
+    assert to_str(b'lel\xf1e', 'latin-1') == u'lel\xf1e'
 
 
-def test_to_unicode_a_unicode_to_unicode_should_return_the_same_object():
-    assert to_unicode(u'\xf1e\xf1e\xf1e') == u'\xf1e\xf1e\xf1e'
+def test_to_str_a_unicode_to_str_should_return_the_same_object():
+    assert to_str(u'\xf1e\xf1e\xf1e') == u'\xf1e\xf1e\xf1e'
 
 
-def test_to_unicode_a_strange_object_should_raise_TypeError():
+def test_to_str_a_strange_object_should_raise_TypeError():
     with pytest.raises(TypeError) as excinfo:
-        to_unicode(123)
+        to_str(123)
 
 
-def test_to_unicode_errors_argument():
-    assert to_unicode(b'a\xedb', 'utf-8', errors='replace') == u'a\ufffdb'
+def test_to_str_errors_argument():
+    assert to_str(b'a\xedb', 'utf-8', errors='replace') == u'a\ufffdb'
 
-# Testing to_unicode conversion
 
+# Testing to_bytes conversion
 
 def test_to_bytes_a_unicode_object_to_an_utf_8_encoded_string():
     assert to_bytes(u'\xa3 49') == b'\xc2\xa3 49'

--- a/tests/test_compat.py
+++ b/tests/test_compat.py
@@ -1,6 +1,56 @@
-import pytest
+import warnings
 
-from scrapy.utils.python import to_bytes, to_unicode
+import pytest
+from scrapy.exceptions import ScrapyDeprecationWarning
+
+from sh_scrapy.compat import is_string, to_bytes, to_unicode, to_native_str
+
+
+# test deprecation messages
+
+def test_deprecated_is_string():
+    with warnings.catch_warnings(record=True) as caught:
+        assert is_string("foo")
+        assert not is_string(b"foo")
+        assert not is_string(1)
+        assert (
+            "is_string(var) is deprecated, please use isinstance(var, str) instead"
+            == str(caught[0].message)
+        )
+        assert caught[0].category is ScrapyDeprecationWarning
+
+
+def test_deprecated_to_unicode():
+    with warnings.catch_warnings(record=True) as caught:
+        assert to_unicode("foo") == "foo"
+        assert to_unicode(b"foo") == "foo"
+        assert (
+            "Call to deprecated function to_unicode. Use scrapy.utils.python.to_unicode instead."
+            == str(caught[0].message)
+        )
+        assert caught[0].category is ScrapyDeprecationWarning
+
+
+def test_deprecated_to_native_str():
+    with warnings.catch_warnings(record=True) as caught:
+        assert to_native_str("foo") == "foo"
+        assert to_native_str(b"foo") == "foo"
+        assert (
+            "Call to deprecated function to_native_str. Use scrapy.utils.python.to_unicode instead."
+            == str(caught[0].message)
+        )
+        assert caught[0].category is ScrapyDeprecationWarning
+
+
+def test_deprecated_to_bytes():
+    with warnings.catch_warnings(record=True) as caught:
+        assert to_bytes("foo") == b"foo"
+        assert to_bytes(b"foo") == b"foo"
+        assert (
+            "Call to deprecated function to_bytes. Use scrapy.utils.python.to_bytes instead."
+            == str(caught[0].message)
+        )
+        assert caught[0].category is ScrapyDeprecationWarning
 
 
 # Testing to_unicode conversion

--- a/tests/test_env.py
+++ b/tests/test_env.py
@@ -5,7 +5,7 @@ import codecs
 import pytest
 import tempfile
 
-from sh_scrapy.compat import to_bytes, to_native_str
+from sh_scrapy.compat import to_bytes, to_str
 
 from sh_scrapy.env import _jobauth
 from sh_scrapy.env import _jobname
@@ -72,7 +72,7 @@ def test_jobname():
 def test_jobauth():
     msg = {'key': '1/2/3', 'auth': 'authstring'}
     expected = codecs.encode(to_bytes('1/2/3:authstring'), 'hex_codec')
-    assert _jobauth(msg) == to_native_str(expected)
+    assert _jobauth(msg) == to_str(expected)
 
 
 def test_get_args_and_env_run_spider():
@@ -88,7 +88,7 @@ def test_get_args_and_env_run_spider():
     assert result[1] == {'SCRAPY_JOB': '1/2/3',
                          'SCRAPY_PROJECT_ID': '1',
                          'SCRAPY_SPIDER': 'test',
-                         'SHUB_JOBAUTH': to_native_str(expected_auth),
+                         'SHUB_JOBAUTH': to_str(expected_auth),
                          'SHUB_JOBKEY': '1/2/3',
                          'SHUB_JOBNAME': 'test',
                          'SHUB_JOB_TAGS': '',
@@ -109,7 +109,7 @@ def test_get_args_and_env_run_script():
     assert len(result) == 2
     assert result[0] == ['custom.py', 'arg1']
     assert result[1] == {
-        'SHUB_JOBAUTH': to_native_str(expected_auth),
+        'SHUB_JOBAUTH': to_str(expected_auth),
         'SHUB_JOBKEY': '1/2/3',
         'SHUB_JOBNAME': 'custom.py',
         'SHUB_JOB_TAGS': ''}

--- a/tests/test_env.py
+++ b/tests/test_env.py
@@ -5,7 +5,7 @@ import codecs
 import pytest
 import tempfile
 
-from sh_scrapy.compat import to_bytes, to_str
+from scrapy.utils.python import to_bytes, to_unicode
 
 from sh_scrapy.env import _jobauth
 from sh_scrapy.env import _jobname
@@ -72,7 +72,7 @@ def test_jobname():
 def test_jobauth():
     msg = {'key': '1/2/3', 'auth': 'authstring'}
     expected = codecs.encode(to_bytes('1/2/3:authstring'), 'hex_codec')
-    assert _jobauth(msg) == to_str(expected)
+    assert _jobauth(msg) == to_unicode(expected)
 
 
 def test_get_args_and_env_run_spider():
@@ -88,7 +88,7 @@ def test_get_args_and_env_run_spider():
     assert result[1] == {'SCRAPY_JOB': '1/2/3',
                          'SCRAPY_PROJECT_ID': '1',
                          'SCRAPY_SPIDER': 'test',
-                         'SHUB_JOBAUTH': to_str(expected_auth),
+                         'SHUB_JOBAUTH': to_unicode(expected_auth),
                          'SHUB_JOBKEY': '1/2/3',
                          'SHUB_JOBNAME': 'test',
                          'SHUB_JOB_TAGS': '',
@@ -109,7 +109,7 @@ def test_get_args_and_env_run_script():
     assert len(result) == 2
     assert result[0] == ['custom.py', 'arg1']
     assert result[1] == {
-        'SHUB_JOBAUTH': to_str(expected_auth),
+        'SHUB_JOBAUTH': to_unicode(expected_auth),
         'SHUB_JOBKEY': '1/2/3',
         'SHUB_JOBNAME': 'custom.py',
         'SHUB_JOB_TAGS': ''}

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -16,7 +16,7 @@ from sh_scrapy.settings import _load_default_settings
 from sh_scrapy.settings import _update_old_classpaths
 from sh_scrapy.settings import populate_settings
 
-from sh_scrapy.compat import to_native_str
+from sh_scrapy.compat import to_str
 
 
 TEST_ADDON = {
@@ -91,7 +91,7 @@ def test_update_settings_check_unicode_in_py2_key():
     test = EntrypointSettings()
     test.setdict({'\xf1e\xf1e\xf1e': 'test'}, 10)
     assert test['\xf1e\xf1e\xf1e'] == 'test'
-    assert test[to_native_str('\xf1e\xf1e\xf1e')] == 'test'
+    assert test[to_str('\xf1e\xf1e\xf1e')] == 'test'
 
 
 @pytest.mark.skipif(sys.version_info[0] == 3, reason="requires python2")
@@ -100,8 +100,8 @@ def test_update_settings_check_unicode_in_py2_key_value():
     test = EntrypointSettings()
     test.setdict({'\xf1e\xf1e\xf1e': '\xf1e\xf1e'}, 10)
     assert test['\xf1e\xf1e\xf1e'] == '\xf1e\xf1e'
-    native_key = to_native_str('\xf1e\xf1e\xf1e')
-    assert test[native_key] == to_native_str('\xf1e\xf1e')
+    native_key = to_str('\xf1e\xf1e\xf1e')
+    assert test[native_key] == to_str('\xf1e\xf1e')
 
 
 @pytest.mark.skipif(sys.version_info < (3,), reason="requires python3")

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -1,10 +1,12 @@
-
 import os
 import sys
 import mock
+
 import pytest
 from scrapy import version_info as scrapy_version
 from scrapy.settings import Settings
+from scrapy.utils.python import to_unicode
+
 from sh_scrapy.settings import EntrypointSettings
 from sh_scrapy.settings import _enforce_required_settings
 from sh_scrapy.settings import _maybe_load_autoscraping_project
@@ -15,8 +17,6 @@ from sh_scrapy.settings import _populate_settings_base
 from sh_scrapy.settings import _load_default_settings
 from sh_scrapy.settings import _update_old_classpaths
 from sh_scrapy.settings import populate_settings
-
-from sh_scrapy.compat import to_str
 
 
 TEST_ADDON = {
@@ -91,7 +91,7 @@ def test_update_settings_check_unicode_in_py2_key():
     test = EntrypointSettings()
     test.setdict({'\xf1e\xf1e\xf1e': 'test'}, 10)
     assert test['\xf1e\xf1e\xf1e'] == 'test'
-    assert test[to_str('\xf1e\xf1e\xf1e')] == 'test'
+    assert test[to_unicode('\xf1e\xf1e\xf1e')] == 'test'
 
 
 @pytest.mark.skipif(sys.version_info[0] == 3, reason="requires python2")
@@ -100,8 +100,8 @@ def test_update_settings_check_unicode_in_py2_key_value():
     test = EntrypointSettings()
     test.setdict({'\xf1e\xf1e\xf1e': '\xf1e\xf1e'}, 10)
     assert test['\xf1e\xf1e\xf1e'] == '\xf1e\xf1e'
-    native_key = to_str('\xf1e\xf1e\xf1e')
-    assert test[native_key] == to_str('\xf1e\xf1e')
+    native_key = to_unicode('\xf1e\xf1e\xf1e')
+    assert test[native_key] == to_unicode('\xf1e\xf1e')
 
 
 @pytest.mark.skipif(sys.version_info < (3,), reason="requires python3")


### PR DESCRIPTION
Use `scrapy.utils.python.to_bytes/to_unicode` instead, available at least since [Scrapy 1.6](https://github.com/scrapy/scrapy/blob/1.6.0/scrapy/utils/python.py#L99-L122) which is currently the [minimum required version](https://github.com/scrapinghub/scrapinghub-entrypoint-scrapy/blob/v0.13.0/setup.py#L11).