### PR TITLE
Remove use of the deprecated binary parameter of the Python item exporter

### DIFF
--- a/sh_scrapy/crawl.py
+++ b/sh_scrapy/crawl.py
@@ -184,7 +184,7 @@ def _launch():
 def list_spiders():
     """ An entrypoint for list-spiders."""
     warnings.warn(
-        "The sh_scrapy.crawl.ignore_warnings function is deprecated.",
+        "The sh_scrapy.crawl.list_spiders function is deprecated.",
         category=SHScrapyDeprecationWarning,
         stacklevel=2,
     )

--- a/sh_scrapy/crawl.py
+++ b/sh_scrapy/crawl.py
@@ -15,6 +15,8 @@ from contextlib import contextmanager
 # and at that point main() function doesn't completed leading to lost log
 # messages.
 
+from sh_scrapy.exceptions import SHScrapyDeprecationWarning
+
 # Keep a reference to standard output/error as they are redirected
 # at log initialization
 _sys_stderr = sys.stderr  # stderr and stoud are redirected to HS later
@@ -51,6 +53,11 @@ def ignore_warnings(**kwargs):
 
     As warnings.catch_warnings, this context manager is not thread-safe.
     """
+    warnings.warn(
+        "The sh_scrapy.crawl.ignore_warnings function is deprecated.",
+        category=SHScrapyDeprecationWarning,
+        stacklevel=2,
+    )
     _filters = warnings.filters[:]
     warnings.filterwarnings('ignore', **kwargs)
     yield
@@ -174,9 +181,13 @@ def _launch():
     _run_usercode(job['spider'], args, _get_apisettings, loghdlr)
 
 
-# TODO: deprecate
 def list_spiders():
     """ An entrypoint for list-spiders."""
+    warnings.warn(
+        "The sh_scrapy.crawl.ignore_warnings function is deprecated.",
+        category=SHScrapyDeprecationWarning,
+        stacklevel=2,
+    )
     try:
         from scrapy.exceptions import ScrapyDeprecationWarning
         warnings.filterwarnings(

--- a/sh_scrapy/extension.py
+++ b/sh_scrapy/extension.py
@@ -41,10 +41,7 @@ class HubstorageExtension(object):
         self.crawler = crawler
         self.logger = logging.getLogger(__name__)
         self._write_item = self.pipe_writer.write_item
-        # https://github.com/scrapy/scrapy/commit/c76190d491fca9f35b6758bdc06c34d77f5d9be9
-        exporter_kwargs = {'binary': False}
-        with ignore_warnings(category=ScrapyDeprecationWarning):
-            self.exporter = PythonItemExporter(**exporter_kwargs)
+        self.exporter = PythonItemExporter()
 
     @classmethod
     def from_crawler(cls, crawler):

--- a/tests/test_crawl.py
+++ b/tests/test_crawl.py
@@ -8,7 +8,6 @@ from scrapy.settings import Settings
 from scrapy.exceptions import ScrapyDeprecationWarning
 
 import sh_scrapy.crawl
-from sh_scrapy.crawl import ignore_warnings
 from sh_scrapy.crawl import _fatalerror
 from sh_scrapy.crawl import _get_apisettings
 from sh_scrapy.crawl import _run
@@ -27,11 +26,6 @@ def test_init_module():
     assert sh_scrapy.crawl._sys_stderr == sys.stderr
     assert sh_scrapy.crawl._sys_stdout == sys.stdout
     assert sh_scrapy.crawl.socket.getdefaulttimeout() == 60.0
-
-
-def test_ignore_warnings():
-    with ignore_warnings(category=ScrapyDeprecationWarning):
-        warnings.warn("must be suppressed", ScrapyDeprecationWarning)
 
 
 @mock.patch('traceback.print_exception')

--- a/tests/test_extension.py
+++ b/tests/test_extension.py
@@ -28,16 +28,6 @@ def test_hs_ext_init(hs_ext):
     assert isinstance(hs_ext.exporter, PythonItemExporter)
 
 
-@pytest.mark.skipif(sys.version_info > (2,), reason="requires python2")
-def test_hs_ext_binary_exporter_py2(hs_ext):
-    assert not hasattr(hs_ext.exporter, 'binary')
-
-
-@pytest.mark.skipif(sys.version_info < (3,), reason="requires python3")
-def test_hs_ext_binary_exporter_py3(hs_ext):
-    assert not getattr(hs_ext.exporter, 'binary')
-
-
 @pytest.mark.skipif(sys.version_info < (3, 7), reason="requires python3.7")
 def test_hs_ext_dataclass_item_scraped(hs_ext):
     from dataclasses import dataclass


### PR DESCRIPTION
Needed for the next Scrapy version due to https://github.com/scrapy/scrapy/pull/6007.