### PR TITLE
Fix duplicated requests in SC UI

### DIFF
--- a/sh_scrapy/middlewares.py
+++ b/sh_scrapy/middlewares.py
@@ -60,6 +60,8 @@ class HubstorageDownloaderMiddleware(object):
             request.meta[HS_PARENT_ID_KEY] = request_id
 
     def process_response(self, request, response, spider):
+        if type(response).__name__ == "DummyResponse":
+            return response
         self.pipe_writer.write_request(
             url=response.url,
             status=response.status,


### PR DESCRIPTION
The fix for two issues:
- requests in Scrapy Cloud are double counted
- there are duplicate requests in SC request list
The idea is to avoid counting requests if the response is DummyResponse class.