### PR TITLE
Fix running scripts with importlib installed.

### DIFF
--- a/sh_scrapy/crawl.py
+++ b/sh_scrapy/crawl.py
@@ -152,7 +152,12 @@ def _run_pkgscript(argv):
 
 
 def _run_script(dist, script_name, namespace):
-    # an importlib-based replacement for pkg_resources.NullProvider.run_script()
+    # An importlib-based replacement for pkg_resources.NullProvider.run_script().
+    # It's possible that this doesn't support all cases that pkg_resources does,
+    # so it may need to be improved when those are discovered.
+    # Using a private attribute (dist._path) seems to be necessary to get the
+    # full file path, but it's only needed for diagnostic messages so it should
+    # be easy to fix this by moving to relative paths if this API is removed.
     script = "scripts/" + script_name
     source = dist.read_text(script)
     if not source:

--- a/tests/test_crawl.py
+++ b/tests/test_crawl.py
@@ -182,19 +182,19 @@ def get_entry_points_mock():
     """Helper to configure a fake entry point"""
     ep = mock.Mock()
     ep.name = 'settings'
-    ep.dist.run_script = mock.Mock()
+    ep.dist.run_script = mock.Mock()  # only for the pkg_resources code path
     return [ep]
 
 @unittest.skipIf(sys.version_info < (3,8), "Requires Python 3.8 or higher")
+@mock.patch('sh_scrapy.crawl._run_script')
 @mock.patch('importlib.metadata.entry_points')
-def test_run_pkgscript_base_usage_python_3_8_plus(entry_points_mock):
+def test_run_pkgscript_base_usage_python_3_8_plus(entry_points_mock, mocked_run):
     entry_points_mock.return_value = get_entry_points_mock()
     _run_pkgscript(['py:script.py', 'arg1', 'arg2'])
     assert entry_points_mock.called
     assert entry_points_mock.call_args[1] == {'group': 'scrapy'}
-    ep = entry_points_mock.return_value[0]
-    assert ep.dist.run_script.called
-    assert ep.dist.run_script.call_args[0] == ('script.py', {'__name__': '__main__'})
+    assert mocked_run.called
+    assert mocked_run.call_args[0][1:] == ('script.py', {'__name__': '__main__'})
     assert sys.argv == ['script.py', 'arg1', 'arg2']
 
 


### PR DESCRIPTION
This fixes a bug introduced in #82 caused by run_script missing in the importlib API. I tested this by deploying a project and running a script shipped by it, both with `zip_safe=False` and `zip_safe=True`. Not sure if there are any other things that can be tested, I cannot test the error code path as Dash doesn't allow running non-existent scripts.