### PR TITLE
Add process_spider_output_async() to the spider middleware.

### DIFF
--- a/sh_scrapy/middlewares.py
+++ b/sh_scrapy/middlewares.py
@@ -39,7 +39,6 @@ class HubstorageSpiderMiddleware(object):
                 self._process_request(x, parent)
             yield x
 
-
     def _process_request(self, request, parent):
         request.meta[HS_PARENT_ID_KEY] = parent
         # Remove request id if it was for some reason set in the request coming from Spider.


### PR DESCRIPTION
Fixes #72.

I wonder how can we test the change on Scrapy Cloud before merging this though?