### PR TITLE
Remove support for Python 3.6 & 3.7

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -5,7 +5,7 @@ on:
 
 jobs:
   publish:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
 
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -10,14 +10,10 @@ jobs:
       fail-fast: false
       matrix:
         include:
-        - python-version: "3.6"
-          os: ubuntu-20.04
+        - python-version: "3.7"
+          os: ubuntu-22.04
           env:
-            TOXENV: py36-scrapy16
-        - python-version: "3.6"
-          os: ubuntu-20.04
-          env:
-            TOXENV: py
+            TOXENV: py-scrapy16
         - python-version: "3.7"
           os: ubuntu-22.04
           env:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -10,14 +10,10 @@ jobs:
       fail-fast: false
       matrix:
         include:
-        - python-version: "3.7"
+        - python-version: "3.8"
           os: ubuntu-22.04
           env:
             TOXENV: py-scrapy16
-        - python-version: "3.7"
-          os: ubuntu-22.04
-          env:
-            TOXENV: py
         - python-version: "3.8"
           os: ubuntu-24.04
           env:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -19,27 +19,27 @@ jobs:
           env:
             TOXENV: py
         - python-version: "3.8"
-          os: ubuntu-latest
+          os: ubuntu-24.04
           env:
             TOXENV: py
         - python-version: "3.9"
-          os: ubuntu-latest
+          os: ubuntu-24.04
           env:
             TOXENV: py
         - python-version: "3.10"
-          os: ubuntu-latest
+          os: ubuntu-24.04
           env:
             TOXENV: py
         - python-version: "3.11"
-          os: ubuntu-latest
+          os: ubuntu-24.04
           env:
             TOXENV: py
         - python-version: "3.12"
-          os: ubuntu-latest
+          os: ubuntu-24.04
           env:
             TOXENV: py
         - python-version: "3.13"
-          os: ubuntu-latest
+          os: ubuntu-24.04
           env:
             TOXENV: py
 

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ setup(
             'shub-image-info = sh_scrapy.crawl:shub_image_info',
         ],
     },
-    python_requires='>=3.7',
+    python_requires='>=3.8',
     classifiers=[
         'Framework :: Scrapy',
         'Development Status :: 5 - Production/Stable',
@@ -30,7 +30,6 @@ setup(
         'Operating System :: OS Independent',
         'Programming Language :: Python',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',
         'Programming Language :: Python :: 3.10',

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ setup(
             'shub-image-info = sh_scrapy.crawl:shub_image_info',
         ],
     },
-    python_requires='>=3.6',
+    python_requires='>=3.7',
     classifiers=[
         'Framework :: Scrapy',
         'Development Status :: 5 - Production/Stable',
@@ -30,7 +30,6 @@ setup(
         'Operating System :: OS Independent',
         'Programming Language :: Python',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',

--- a/tests/test_extension.py
+++ b/tests/test_extension.py
@@ -6,7 +6,7 @@ import pytest
 import scrapy
 from packaging import version
 from pytest import warns
-from scrapy import Spider
+from scrapy import Spider, version_info as SCRAPY_VERSION_INFO
 from scrapy.exporters import PythonItemExporter
 from scrapy.http import Request, Response
 from scrapy.item import Item
@@ -31,7 +31,7 @@ def test_hs_ext_init(hs_ext):
     assert hs_ext.exporter.export_item({"a": "b"}) == {"a": "b"}
 
 
-@pytest.mark.skipif(sys.version_info < (3, 7), reason="requires python3.7")
+@pytest.mark.skipif(SCRAPY_VERSION_INFO < (2, 2, 0), reason="Requires Scrapy>=2.2")
 def test_hs_ext_dataclass_item_scraped(hs_ext):
     from dataclasses import dataclass
 
@@ -47,6 +47,7 @@ def test_hs_ext_dataclass_item_scraped(hs_ext):
     assert hs_ext._write_item.call_args[0] == ({'_type': 'DataclassItem'},)
 
 
+@pytest.mark.skipif(SCRAPY_VERSION_INFO < (2, 2, 0), reason="Requires Scrapy>=2.2")
 def test_hs_ext_attrs_item_scraped(hs_ext):
     try:
         import attr

--- a/tox.ini
+++ b/tox.ini
@@ -13,6 +13,7 @@ deps =
     hubstorage
     packaging
     py-scrapy16: Scrapy==1.6
+    py-scrapy16: Twisted==19.10.0
     scrapy-spider-metadata>=0.1.1; python_version >= "3.8"
     pydantic>=2; python_version >= "3.8"
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 # tox.ini
 [tox]
-envlist = py36-scrapy16, py
+envlist = py-scrapy16, py
 requires =
     # https://github.com/pypa/virtualenv/issues/2550
     virtualenv<=20.21.1
@@ -12,7 +12,7 @@ deps =
     mock
     hubstorage
     packaging
-    py36-scrapy16: Scrapy==1.6
+    py-scrapy16: Scrapy==1.6
     scrapy-spider-metadata>=0.1.1; python_version >= "3.8"
     pydantic>=2; python_version >= "3.8"
 


### PR DESCRIPTION
Python 3.6 reached EOL on 2021-12-23 (https://devguide.python.org/versions/#unsupported-versions). Furthermore, test runs are [being cancelled](https://github.com/scrapinghub/scrapinghub-entrypoint-scrapy/actions/runs/15446264387/job/43477008659) because the `ubuntu-20.04` image is no longer available.