### PR TITLE
Install the Twisted reactor explicitly in tests.

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -33,3 +33,7 @@ def set_jobkeyenvironment(monkeypatch):
     monkeypatch.setenv('SCRAPY_JOB', '1/2/3')
     monkeypatch.setenv('SHUB_JOBAUTH', TEST_AUTH)
     monkeypatch.setenv('SHUB_STORAGE', 'storage-url')
+
+
+# install the reactor explicitly, as Scrapy including scrapy.utils.test.get_crawler() assumes it's installed
+from twisted.internet import reactor


### PR DESCRIPTION
This fixes test failures with Scrapy 2.13+, where `is_asyncio_reactor_installed()` no longer silently installs the reactor but raises an exception if it's not installed.