### PR TITLE
Cleanup

### DIFF
--- a/sh_scrapy/commands/shub_image_info.py
+++ b/sh_scrapy/commands/shub_image_info.py
@@ -18,7 +18,7 @@ class Command(ScrapyCommand):
         return "Print JSON-encoded project metadata."
 
     def add_options(self, parser):
-        super(Command, self).add_options(parser)
+        super().add_options(parser)
         # backward compatibility for optparse/argparse
         try:
             add_argument = parser.add_argument

--- a/sh_scrapy/commands/shub_image_info.py
+++ b/sh_scrapy/commands/shub_image_info.py
@@ -1,5 +1,4 @@
 # -*- coding: utf-8 -*-
-from __future__ import print_function
 import json
 import subprocess
 

--- a/sh_scrapy/commands/shub_image_info.py
+++ b/sh_scrapy/commands/shub_image_info.py
@@ -19,12 +19,7 @@ class Command(ScrapyCommand):
 
     def add_options(self, parser):
         super().add_options(parser)
-        # backward compatibility for optparse/argparse
-        try:
-            add_argument = parser.add_argument
-        except AttributeError:
-            add_argument = parser.add_option
-        add_argument(
+        parser.add_argument(
             "--debug",
             action="store_true",
             help="add debugging information such as list of "

--- a/sh_scrapy/crawl.py
+++ b/sh_scrapy/crawl.py
@@ -2,6 +2,7 @@
 # --------------------- DO NOT ADD IMPORTS HERE -------------------------
 # Add them below so that any import errors are caught and sent to sentry
 # -----------------------------------------------------------------------
+import datetime as dt
 import logging
 import os
 import socket
@@ -9,7 +10,6 @@ import sys
 import sysconfig
 import warnings
 from contextlib import contextmanager
-from datetime import timezone, datetime as dt
 from importlib.metadata import entry_points, PathDistribution
 from pathlib import Path
 from typing import Tuple
@@ -88,14 +88,14 @@ def _fatalerror():
             try:
                 Client(_sentry_dsn).captureException()
             except Exception as err:
-                print(dt.now(timezone.utc).isoformat(),
+                print(dt.datetime.now(dt.timezone.utc).isoformat(),
                       "Error when sending fatal error to sentry:", err,
                       file=_sys_stderr)
 
     # Log error to hworker slotN.out
     # Inspired by logging.Handler.handleError()
     try:
-        print(dt.now(timezone.utc).isoformat(), end=' ',
+        print(dt.datetime.now(dt.timezone.utc).isoformat(), end=' ',
               file=_sys_stderr)
         traceback.print_exception(ei[0], ei[1], ei[2], None, _sys_stderr)
     except IOError:

--- a/sh_scrapy/crawl.py
+++ b/sh_scrapy/crawl.py
@@ -2,7 +2,6 @@
 # --------------------- DO NOT ADD IMPORTS HERE -------------------------
 # Add them below so that any import errors are caught and sent to sentry
 # -----------------------------------------------------------------------
-from __future__ import print_function
 import datetime
 import logging
 import os

--- a/sh_scrapy/crawl.py
+++ b/sh_scrapy/crawl.py
@@ -10,7 +10,7 @@ import sys
 import sysconfig
 import warnings
 from contextlib import contextmanager
-from importlib.metadata import PathDistribution
+from importlib.metadata import entry_points, PathDistribution
 from pathlib import Path
 from typing import Tuple
 
@@ -128,31 +128,16 @@ def _run_pkgscript(argv):
     scriptname = argv[0]
     sys.argv = argv
 
-    try:
-        import importlib.metadata
-        has_importlib = True
-    except ImportError:
-        import pkg_resources
-        has_importlib = False
+    dist = None
+    for ep in entry_points(group='scrapy'):
+        if ep.name == 'settings':
+            dist = ep.dist
+            break
 
-    def get_distribution():
-        if has_importlib:
-            eps = importlib.metadata.entry_points(group='scrapy')
-        else:
-            eps = pkg_resources.WorkingSet().iter_entry_points('scrapy')
-
-        for ep in eps:
-            if ep.name == 'settings':
-                return ep.dist
-
-    d = get_distribution()
-    if not d:
+    if not dist:
         raise ValueError(SCRAPY_SETTINGS_ENTRYPOINT_NOT_FOUND)
     ns = {"__name__": "__main__"}
-    if has_importlib:
-        _run_script(d, scriptname, ns)
-    else:
-        d.run_script(scriptname, ns)
+    _run_script(dist, scriptname, ns)
 
 
 def _get_script_code_and_path(dist: PathDistribution, script_name: str) -> Tuple[str, str]:
@@ -176,12 +161,14 @@ def _get_script_code_and_path(dist: PathDistribution, script_name: str) -> Tuple
 
 
 def _run_script(dist: PathDistribution, script_name: str, namespace: dict) -> None:
-    # An importlib-based replacement for pkg_resources.NullProvider.run_script().
-    # It's possible that this doesn't support all cases that pkg_resources does,
-    # so it may need to be improved when those are discovered.
-    # Using a private attribute (dist._path) seems to be necessary to get the
-    # full file path, but it's only needed for diagnostic messages so it should
-    # be easy to fix this by moving to relative paths if this API is removed.
+    """An importlib-based replacement for pkg_resources.NullProvider.run_script().
+
+    It's possible that this doesn't support all cases that pkg_resources does,
+    so it may need to be improved when those are discovered.
+    Using a private attribute (dist._path) seems to be necessary to get the
+    full file path, but it's only needed for diagnostic messages so it should
+    be easy to fix this by moving to relative paths if this API is removed.
+    """
     source, script_filename = _get_script_code_and_path(dist, script_name)
     if source is None:
         raise ValueError(

--- a/sh_scrapy/crawl.py
+++ b/sh_scrapy/crawl.py
@@ -2,7 +2,6 @@
 # --------------------- DO NOT ADD IMPORTS HERE -------------------------
 # Add them below so that any import errors are caught and sent to sentry
 # -----------------------------------------------------------------------
-import datetime
 import logging
 import os
 import socket
@@ -10,6 +9,7 @@ import sys
 import sysconfig
 import warnings
 from contextlib import contextmanager
+from datetime import timezone, datetime as dt
 from importlib.metadata import entry_points, PathDistribution
 from pathlib import Path
 from typing import Tuple
@@ -88,14 +88,14 @@ def _fatalerror():
             try:
                 Client(_sentry_dsn).captureException()
             except Exception as err:
-                print(datetime.datetime.utcnow().isoformat(),
+                print(dt.now(timezone.utc).isoformat(),
                       "Error when sending fatal error to sentry:", err,
                       file=_sys_stderr)
 
     # Log error to hworker slotN.out
     # Inspired by logging.Handler.handleError()
     try:
-        print(datetime.datetime.utcnow().isoformat(), end=' ',
+        print(dt.now(timezone.utc).isoformat(), end=' ',
               file=_sys_stderr)
         traceback.print_exception(ei[0], ei[1], ei[2], None, _sys_stderr)
     except IOError:

--- a/sh_scrapy/extension.py
+++ b/sh_scrapy/extension.py
@@ -31,7 +31,7 @@ else:
         return ItemAdapter.is_item(item)
 
 
-class HubstorageExtension(object):
+class HubstorageExtension:
     """Extension to write scraped items to HubStorage"""
 
     def __init__(self, crawler):

--- a/sh_scrapy/hsref.py
+++ b/sh_scrapy/hsref.py
@@ -7,7 +7,7 @@ from codecs import decode
 from scrapy.utils.python import to_unicode
 
 
-class _HubstorageRef(object):
+class _HubstorageRef:
 
     def __init__(self):
         self.enabled = 'SHUB_JOBKEY' in os.environ

--- a/sh_scrapy/log.py
+++ b/sh_scrapy/log.py
@@ -85,7 +85,7 @@ class HubstorageLogHandler(logging.Handler):
         cur = sys.stderr
         try:
             sys.stderr = _stderr
-            super(HubstorageLogHandler, self).handleError(record)
+            super().handleError(record)
         finally:
             sys.stderr = cur
 

--- a/sh_scrapy/log.py
+++ b/sh_scrapy/log.py
@@ -90,7 +90,7 @@ class HubstorageLogHandler(logging.Handler):
             sys.stderr = cur
 
 
-class HubstorageLogObserver(object):
+class HubstorageLogObserver:
     """Twisted log observer with Scrapy specifics that writes to HubStorage"""
 
     def __init__(self, loghdlr):

--- a/sh_scrapy/settings.py
+++ b/sh_scrapy/settings.py
@@ -48,18 +48,18 @@ class EntrypointSettings(Settings):
     """
 
     def __init__(self):
-        super(EntrypointSettings, self).__init__()
+        super().__init__()
         self.attributes = {}
 
     def set(self, name, value, priority='project'):
-        super(EntrypointSettings, self).set(
+        super().set(
             to_unicode(name),
             value if isinstance(value, str) else value,
             priority=priority)
 
     def copy_to_dict(self):
-        if hasattr(super(EntrypointSettings, self), 'copy_to_dict'):
-            return super(EntrypointSettings, self).copy_to_dict()
+        if hasattr(super(), 'copy_to_dict'):
+            return super().copy_to_dict()
         # Backward compatibility with older Scrapy versions w/o copy_to_dict
         settings = self.copy()
         return {key: settings[key] for key in settings.attributes}

--- a/sh_scrapy/stats.py
+++ b/sh_scrapy/stats.py
@@ -12,7 +12,7 @@ class HubStorageStatsCollector(StatsCollector):
     INTERVAL = 30
 
     def __init__(self, crawler: Crawler):
-        super(HubStorageStatsCollector, self).__init__(crawler)
+        super().__init__(crawler)
         self.hsref = hsref.hsref
         self.pipe_writer = pipe_writer
 

--- a/sh_scrapy/writer.py
+++ b/sh_scrapy/writer.py
@@ -11,7 +11,7 @@ def _not_configured(*args, **kwargs):
     raise RuntimeError("Pipe writer is misconfigured, named pipe path is not set")
 
 
-class _PipeWriter(object):
+class _PipeWriter:
     """Writer for the Scrapinghub named pipe.
 
     It's not safe to instantiate and use multiple writers, only one writer

--- a/tests/test_command.py
+++ b/tests/test_command.py
@@ -1,10 +1,8 @@
 
 from argparse import ArgumentParser
-from optparse import OptionParser
 
 import pytest
 import scrapy
-from packaging import version
 
 from sh_scrapy.commands.shub_image_info import Command
 
@@ -16,21 +14,6 @@ def command():
     return command
 
 
-@pytest.mark.skipif(
-    version.parse(scrapy.__version__) >= version.parse("2.6"),
-    reason="Scrapy>=2.6 uses argparse"
-)
-def test_optparse(command):
-    parser = OptionParser()
-    command.add_options(parser)
-    options = parser.parse_args(["--debug"])
-    assert options[0].debug
-
-
-@pytest.mark.skipif(
-    version.parse(scrapy.__version__) < version.parse("2.6"),
-    reason="Scrapy<2.6 uses optparse"
-)
 def test_argparse(command):
     parser = ArgumentParser()
     command.add_options(parser)

--- a/tests/test_crawl.py
+++ b/tests/test_crawl.py
@@ -187,7 +187,7 @@ def get_entry_points_mock():
 
 @unittest.skipIf(sys.version_info < (3,8), "Requires Python 3.8 or higher")
 @mock.patch('sh_scrapy.crawl._run_script')
-@mock.patch('importlib.metadata.entry_points')
+@mock.patch('sh_scrapy.crawl.entry_points')
 def test_run_pkgscript_base_usage_python_3_8_plus(entry_points_mock, mocked_run):
     entry_points_mock.return_value = get_entry_points_mock()
     _run_pkgscript(['py:script.py', 'arg1', 'arg2'])

--- a/tests/test_crawl.py
+++ b/tests/test_crawl.py
@@ -3,7 +3,6 @@ import sys
 import json
 import mock
 import pytest
-import unittest
 from scrapy.settings import Settings
 
 import sh_scrapy.crawl
@@ -121,18 +120,8 @@ def test_run_pkg_script(run_pkg_mock):
     assert run_pkg_mock.call_args[0] == (['py:script.py'],)
 
 
-@unittest.skipIf(sys.version_info > (3,7), "Requires Python 3.7 or lower")
-@mock.patch('pkg_resources.WorkingSet')
-def test_run_pkg_script_distribution_not_found(working_set_class):
-    fake_set = mock.Mock()
-    fake_set.iter_entry_points.return_value = iter(())
-    working_set_class.return_value = fake_set
-    with pytest.raises(ValueError):
-        _run(['py:script.py'], {'SETTING': 'VALUE'})
-
-@unittest.skipIf(sys.version_info < (3,8), "Requires Python 3.8 or higher")
 @mock.patch('importlib.metadata.entry_points')
-def test_run_pkg_script_distribution_not_found_python_3_8_plus(working_set_class):
+def test_run_pkg_script_distribution_not_found(working_set_class):
     fake_set = mock.Mock()
     fake_set.iter_entry_points.return_value = iter(())
     working_set_class.return_value = [fake_set]
@@ -156,28 +145,6 @@ def test_run_scrapy(execute_mock):
     assert sys.argv == ['scrapy', 'crawl', 'spider']
 
 
-def get_working_set(working_set_class):
-    """Helper to confugure a fake working set with ep"""
-    working_set = working_set_class.return_value
-    ep = mock.Mock()
-    ep.name = 'settings'
-    working_set.iter_entry_points.return_value = [ep]
-    return working_set
-
-
-@unittest.skipIf(sys.version_info > (3,7), "Requires Python 3.7 or lower")
-@mock.patch('pkg_resources.WorkingSet')
-def test_run_pkgscript_base_usage(working_set_class):
-    working_set = get_working_set(working_set_class)
-    _run_pkgscript(['py:script.py', 'arg1', 'arg2'])
-    assert working_set.iter_entry_points.called
-    assert working_set.iter_entry_points.call_args[0] == ('scrapy',)
-    ep = working_set.iter_entry_points.return_value[0]
-    assert ep.dist.run_script.called
-    assert ep.dist.run_script.call_args[0] == (
-        'script.py', {'__name__': '__main__'})
-    assert sys.argv == ['script.py', 'arg1', 'arg2']
-
 def get_entry_points_mock():
     """Helper to configure a fake entry point"""
     ep = mock.Mock()
@@ -185,10 +152,10 @@ def get_entry_points_mock():
     ep.dist.run_script = mock.Mock()  # only for the pkg_resources code path
     return [ep]
 
-@unittest.skipIf(sys.version_info < (3,8), "Requires Python 3.8 or higher")
+
 @mock.patch('sh_scrapy.crawl._run_script')
 @mock.patch('sh_scrapy.crawl.entry_points')
-def test_run_pkgscript_base_usage_python_3_8_plus(entry_points_mock, mocked_run):
+def test_run_pkgscript_base_usage(entry_points_mock, mocked_run):
     entry_points_mock.return_value = get_entry_points_mock()
     _run_pkgscript(['py:script.py', 'arg1', 'arg2'])
     assert entry_points_mock.called

--- a/tests/test_extension.py
+++ b/tests/test_extension.py
@@ -57,7 +57,7 @@ def test_hs_ext_attrs_item_scraped(hs_ext):
         return
 
     @attr.s
-    class AttrsItem(object):
+    class AttrsItem:
         pass
 
     hs_ext._write_item = mock.Mock()

--- a/tests/test_log.py
+++ b/tests/test_log.py
@@ -1,9 +1,7 @@
-import json
 import logging
 import mock
 import pytest
 import sys
-import zlib
 
 from sh_scrapy.log import _stdout, _stderr
 from sh_scrapy.log import initialize_logging
@@ -215,19 +213,3 @@ def test_stdout_logger_writelines(pipe_writer):
     logger.writelines(['test-line'])
     assert pipe_writer.write_log.called
     pipe_writer.write_log.assert_called_with(level=20, message='[stdout] test-line')
-
-
-@pytest.mark.skipif(sys.version_info[0] == 3, reason="requires python2")
-@mock.patch('sh_scrapy.log.pipe_writer._pipe')
-def test_unicode_decode_error_handling(pipe_mock):
-    hdlr = HubstorageLogHandler()
-    message = 'value=%s' % zlib.compress('value')
-    record = logging.makeLogRecord({'msg': message, 'levelno': 10})
-    hdlr.emit(record)
-    assert pipe_mock.write.called
-    payload = json.loads(pipe_mock.write.call_args_list[2][0][0])
-    assert isinstance(payload.pop('time'), int)
-    assert payload == {
-        'message': r'value=x\x9c+K\xcc)M\x05\x00\x06j\x02\x1e',
-        'level': 10
-    }

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -1,11 +1,8 @@
 import os
-import sys
 import mock
 
 import pytest
-from scrapy import version_info as scrapy_version
 from scrapy.settings import Settings
-from scrapy.utils.python import to_unicode
 
 from sh_scrapy.settings import EntrypointSettings
 from sh_scrapy.settings import _enforce_required_settings
@@ -74,7 +71,6 @@ def test_update_settings_per_key_priorities_old_behavior():
     assert test['ITEM_PIPELINES'] == {'path.two': 200}
 
 
-@pytest.mark.skipif(scrapy_version < (1, 1), reason="requires Scrapy>=1.1")
 def test_update_settings_per_key_priorities_new_behaviour():
     from scrapy.settings import BaseSettings
     test = EntrypointSettings()
@@ -85,27 +81,7 @@ def test_update_settings_per_key_priorities_new_behaviour():
         'test.path1': 100, 'test.path2': 200}
 
 
-@pytest.mark.skipif(sys.version_info[0] == 3, reason="requires python2")
-def test_update_settings_check_unicode_in_py2_key():
-    # a dict entry is duplicated as unicode doesn't match native str value
-    test = EntrypointSettings()
-    test.setdict({'\xf1e\xf1e\xf1e': 'test'}, 10)
-    assert test['\xf1e\xf1e\xf1e'] == 'test'
-    assert test[to_unicode('\xf1e\xf1e\xf1e')] == 'test'
-
-
-@pytest.mark.skipif(sys.version_info[0] == 3, reason="requires python2")
-def test_update_settings_check_unicode_in_py2_key_value():
-    # a dict entry is duplicated as unicode doesn't match native str value
-    test = EntrypointSettings()
-    test.setdict({'\xf1e\xf1e\xf1e': '\xf1e\xf1e'}, 10)
-    assert test['\xf1e\xf1e\xf1e'] == '\xf1e\xf1e'
-    native_key = to_unicode('\xf1e\xf1e\xf1e')
-    assert test[native_key] == to_unicode('\xf1e\xf1e')
-
-
-@pytest.mark.skipif(sys.version_info < (3,), reason="requires python3")
-def test_update_settings_check_unicode_in_py3():
+def test_update_settings_check_unicode():
     test = EntrypointSettings()
     test.setdict({'\xf1e\xf1e\xf1e': 'test'}, 10)
     assert test['\xf1e\xf1e\xf1e'] == 'test'

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -404,7 +404,7 @@ def test_populate_settings_check_required():
 
 def test_update_old_classpaths_not_string():
 
-    class CustomObject(object):
+    class CustomObject:
         pass
 
     test_value = {'scrapy.exporter.CustomExporter': 1,


### PR DESCRIPTION
Several unrelated cleanups:

- Remove from future import print_function
- Always use importlib.metadata instead of pkg_resources
- Replace deprecated utcnow calls
- Remove object parent class
- Modernize super() calls
- Remove python2-only tests
- Always use argparse 